### PR TITLE
[AD] 코스 리스트 페이지 '텍스트 필드'에서 '레퍼런스 필드'로 변경

### DIFF
--- a/admin/src/companies/CompanyList.jsx
+++ b/admin/src/companies/CompanyList.jsx
@@ -3,7 +3,10 @@ import {
     Datagrid,
     TextField,
     UrlField,
-    Pagination
+    Pagination,
+    ReferenceManyField,
+    SingleFieldList,
+    ChipField
 } from 'react-admin';
 
 const CompanyPagination = props => <Pagination rowsPerPageOptions={[10, 25, 50, 100]} {...props} />;
@@ -15,6 +18,14 @@ export const CompanyList = (props) => (
             <TextField source="name" label="회사명" />
             <UrlField source="url" label="회사 URL" />
             <TextField source="courses" label="개설 코스" />
+
+            {/* to-do: target 작동하지 않음 -> react-admin 디스코드 채널에 질문*/}
+            {/*<ReferenceManyField label="개설 코스" reference="courses" target="companyId" >*/}
+            {/*    <SingleFieldList>*/}
+            {/*        <ChipField source="title" />*/}
+            {/*    </SingleFieldList>*/}
+            {/*</ReferenceManyField>*/}
+
         </Datagrid>
     </List>
 );

--- a/admin/src/courses/CourseList.jsx
+++ b/admin/src/courses/CourseList.jsx
@@ -6,7 +6,8 @@ import {
     ChipField,
     NumberField,
     UrlField,
-    Pagination
+    Pagination,
+    ReferenceField
 } from 'react-admin';
 
 const CoursePagination = props => <Pagination rowsPerPageOptions={[10, 25, 50, 100]} {...props} />;
@@ -20,7 +21,9 @@ export const CourseList = (props) => (
             <TextField source="id" />
             <TextField source="title" label="코스 타이틀" />
             <UrlField source="url" label="코스 URL" />
-            <TextField source="companyName" label="회사명" />
+            <ReferenceField source="companyId" reference="companies" label="회사명">
+                <TextField source="name" />
+            </ReferenceField>
             <TextField source="dates.registrationStartDate" label="등록 시작" />
             <TextField source="dates.registrationEndDate" label="등록 마감" />
             <TextField source="dates.courseStartDate" label="코스 시작" />

--- a/backend/src/main/java/com/bootme/course/dto/CourseResponse.java
+++ b/backend/src/main/java/com/bootme/course/dto/CourseResponse.java
@@ -14,6 +14,7 @@ public class CourseResponse {
     private Long id;
     private String title;
     private String url;
+    private Long companyId;
     private String companyName;
     private String location;
     private int cost;
@@ -30,12 +31,13 @@ public class CourseResponse {
 
     @Builder
     public CourseResponse(Long id, String title, String url, String companyName,
-                          String location, int cost, String costType, Dates dates,
+                          Long companyId, String location, int cost, String costType, Dates dates,
                           String onOffline, List<Tag> tags, String prerequisites,
                           boolean recommended, boolean tested) {
         this.id = id;
         this.title = title;
         this.url = url;
+        this.companyId = companyId;
         this.companyName = companyName;
         this.location = location;
         this.cost = cost;
@@ -55,6 +57,7 @@ public class CourseResponse {
                 .id(course.getId())
                 .title(course.getTitle())
                 .url(course.getUrl())
+                .companyId(course.getCompany().getId())
                 .companyName(course.getCompany().getName())
                 .location(course.getLocation())
                 .cost(course.getCost())

--- a/backend/src/test/java/com/bootme/util/fixture/CourseFixture.java
+++ b/backend/src/test/java/com/bootme/util/fixture/CourseFixture.java
@@ -185,6 +185,7 @@ public class CourseFixture {
             .id(1L)
             .title(VALID_TITLE_1)
             .url(VALID_URL_1)
+            .companyId(1L)
             .companyName(VALID_COMPANY_1.getName())
             .location(VALID_LOCATION_1)
             .cost(VALID_COST_1)
@@ -201,6 +202,7 @@ public class CourseFixture {
             .id(2L)
             .title(VALID_TITLE_2)
             .url(VALID_URL_2)
+            .companyId(2L)
             .companyName(VALID_COMPANY_2.getName())
             .location(VALID_LOCATION_2)
             .cost(VALID_COST_2)
@@ -217,6 +219,7 @@ public class CourseFixture {
             .id(3L)
             .title(VALID_TITLE_3)
             .url(VALID_URL_3)
+            .companyId(3L)
             .companyName(VALID_COMPANY_3.getName())
             .location(VALID_LOCATION_3)
             .cost(VALID_COST_3)
@@ -245,18 +248,21 @@ public class CourseFixture {
             .build();
 
     public static final CompanyResponse VALID_COMPANY_RESPONSE_1 = CompanyResponse.builder()
+            .id(1L)
             .url(VALID_COM_URL_1)
             .name(VALID_COM_NAME_1)
             .courses(new ArrayList<>(Arrays.asList("네이버 부트캠프", "카카오 부트캠프", "라인 부트캠프")))
             .build();
 
     public static final CompanyResponse VALID_COMPANY_RESPONSE_2 = CompanyResponse.builder()
+            .id(2L)
             .url(VALID_COM_URL_2)
             .name(VALID_COM_NAME_2)
             .courses(new ArrayList<>(Arrays.asList("쿠팡 부트캠프", "배민 부트캠프", "토스 부트캠프")))
             .build();
 
     public static final CompanyResponse VALID_COMPANY_RESPONSE_3 = CompanyResponse.builder()
+            .id(3L)
             .url(VALID_COM_URL_3)
             .name(VALID_COM_NAME_3)
             .courses(new ArrayList<>(Arrays.asList("페이스북 부트캠프", "아마존 부트캠프", "구글 부트캠프")))


### PR DESCRIPTION
## AS-IS
![image](https://user-images.githubusercontent.com/44575214/207358032-926990e9-529c-443d-9b52-de5380d599da.png)

## TO-BE
![image](https://user-images.githubusercontent.com/44575214/207358071-ca6f7dd2-f997-42a0-8b67-fa02798b7b53.png)

- 회사 리스트 페이지의 '개설 코스' 컬럼도 'ReferenceManyField'로 변경하려 하였으나, 필수 prop 중 하나인 target이 정상작동 하지 않아서 우선 그대로 텍스트 필드 유지함. 추후 해결 필요


<br>





***

close #50 







