### PR TITLE
[BE] CORS 허용 방식 변경

### DIFF
--- a/admin/webpack.dev.js
+++ b/admin/webpack.dev.js
@@ -6,7 +6,7 @@ module.exports = merge(common, {
   devtool: 'eval',
   devServer: {
     historyApiFallback: true,
-    port: 3000,
+    port: 3001,
     hot: true,
   },
 });

--- a/backend/src/main/java/com/bootme/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/bootme/admin/controller/AdminController.java
@@ -15,8 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
-
-@CrossOrigin(origins = "http://localhost:3000/")
+@CrossOrigin
 @RestController
 @RequestMapping("/admin")
 @RequiredArgsConstructor
@@ -76,7 +75,7 @@ public class AdminController {
         CompanyResponse companyResponse = adminService.findCompanyById(companyId);
         HttpHeaders headers = new HttpHeaders();
         headers.add("Location", "/companies/" + companyId);
-        return new ResponseEntity(companyResponse, headers, HttpStatus.CREATED);
+        return new ResponseEntity<>(companyResponse, headers, HttpStatus.CREATED);
     }
 
     @GetMapping("/companies/{id}")

--- a/backend/src/main/java/com/bootme/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/bootme/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.bootme.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,DELETE,TRACE,OPTIONS,PATCH,PUT";
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000", "http://localhost:3001")
+                .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
## 설명
`@CrossOrigin`을 컨트롤러 클래스마다 붙이면 코드 반복되기 때문에 변경

## AS-IS
컨트롤러 클래스에 `@CrossOrigin` 어노테이션 붙여서 CORS 허용

## TO-BE
- `WebMvcConfigurer` 구현 클래스 `WebMvcConfig` 작성하여 CORS 허용
- 어드민 개발 서버 포트 3001로 변경 (프론트 개발 서버와 겹치지 않도록)

<br>

_**Reference**
https://github.com/woowacourse-teams/2022-sokdak/commit/c8610d1162873523e487267d0782a0d099ee9b59
https://wonit.tistory.com/572_

***

close #70 







