### PR TITLE
[FE] 로그아웃 구현

### DIFF
--- a/frontend/src/components/@common/Header/index.tsx
+++ b/frontend/src/components/@common/Header/index.tsx
@@ -8,14 +8,13 @@ import LoginModal from '../../LoginModal';
 import { GoogleLoginOneTap } from '../../LoginModal/GoogleLogin';
 
 const Header = () => {
+  const { handleLoginModal, handleLogOut } = useLogin();
   const isLogin: boolean = JSON.parse(localStorage.getItem('Login') || 'false');
-  const username = '로그인 됨';
-
   const [displaySpan, setDisplaySpan] = useState(1);
+
   const handleClick = () => {
     setDisplaySpan(displaySpan === 1 ? 2 : 1);
   };
-  const { handleLoginModal } = useLogin();
 
   return (
     <>
@@ -36,8 +35,10 @@ const Header = () => {
             <HeaderItem> 커뮤니티 </HeaderItem>
           </HeaderLeft>
           <HeaderRight>
-            {isLogin && username ? (
-              <>{username}</>
+            {isLogin ? (
+              <>
+                <div onClick={handleLogOut}>로그아웃</div>
+              </>
             ) : (
               <>
                 <LogIn onClick={handleLoginModal}>로그인</LogIn>

--- a/frontend/src/hooks/useLogin.tsx
+++ b/frontend/src/hooks/useLogin.tsx
@@ -5,10 +5,12 @@ const LoginContext = createContext<LoginContextProps>({
   isLoginModal: false,
   handleLoginModal: () => {},
   sendIdTokenToServer: () => {},
+  handleLogOut: () => {},
 });
 
 export const LoginProvider = ({ children }: LoginProviderProps) => {
   const [isLoginModal, setIsLoginModal] = useState(false);
+
   const handleLoginModal = () => {
     isLoginModal ? setIsLoginModal(false) : setIsLoginModal(true);
   };
@@ -25,12 +27,24 @@ export const LoginProvider = ({ children }: LoginProviderProps) => {
       });
   };
 
+  const handleLogOut = () => {
+    fetcher
+      .post('/logout', null, {})
+      .then(() => {
+        location.reload();
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  };
+
   return (
     <LoginContext.Provider
       value={{
         isLoginModal,
         handleLoginModal,
         sendIdTokenToServer,
+        handleLogOut,
       }}
     >
       {children}
@@ -44,6 +58,7 @@ interface LoginContextProps {
   isLoginModal: boolean;
   handleLoginModal: () => void;
   sendIdTokenToServer: (idToken: string | undefined) => void;
+  handleLogOut: () => void;
 }
 
 interface LoginProviderProps {


### PR DESCRIPTION
### useLogin.handleLogOut()
  ```javascript
  const handleLogOut = () => {
    fetcher
      .post('/logout', null, {})
      .then(() => {
        location.reload();
      })
      .catch(error => {
        console.log(error);
      });
  };
```
- `/logout` 으로 POST 요청시 응답 수신 이후 accessToken, refreshToken이 삭제됨
  - 서버 응답에서 기존 토큰을 만료시간 0으로 설정한 토큰으로 덮어씌워서 삭제함


<br>

***

close #120 







