### PR TITLE
[BE] 엔티티 클래스에 @CreatedDate, @LastModifiedDate 적용

### DIFF
--- a/backend/src/main/java/com/bootme/BootmeApplication.java
+++ b/backend/src/main/java/com/bootme/BootmeApplication.java
@@ -2,7 +2,9 @@ package com.bootme;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BootmeApplication {
 

--- a/backend/src/main/java/com/bootme/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bootme/auth/controller/AuthController.java
@@ -47,7 +47,6 @@ public class AuthController {
 
         boolean isRegistered = memberService.isMemberRegistered(jwtBody.getEmail());
         if (isRegistered) {
-            authService.updateLastLogin(jwtBody);
             authService.incrementVisitsCount(jwtBody);
         } else {
             authService.registerMember(jwtBody);

--- a/backend/src/main/java/com/bootme/auth/service/AuthService.java
+++ b/backend/src/main/java/com/bootme/auth/service/AuthService.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.Objects;
 
@@ -48,14 +47,6 @@ public class AuthService {
         return OAuthProvider;
     }
 
-    // todo: 라스트 세션으로 수정해야할듯
-    public void updateLastLogin(JwtVo.Body jwtBody) throws Exception {
-        int rowsAffected = memberRepository.updateLastLoginTime(jwtBody.getEmail(), LocalDateTime.now());
-        // todo: 예외처리
-        if (rowsAffected != 1){
-            throw new Exception();
-        }
-    }
 
     // todo: 세션 카운트로 수정해야할듯
     public void incrementVisitsCount(JwtVo.Body jwtBody) throws Exception {

--- a/backend/src/main/java/com/bootme/member/domain/Member.java
+++ b/backend/src/main/java/com/bootme/member/domain/Member.java
@@ -5,6 +5,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -12,6 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class Member {
 
     @Id
@@ -47,14 +51,16 @@ public class Member {
 
     private Long visitsCount;
 
+    @CreatedDate
     private LocalDateTime createdAt;
 
-    private LocalDateTime lastLoginAt;
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
 
     @Builder
     public Member(String email, String password, String OAuthProvider, String name, String profileImage,
                   String birthday, String birthYear, String ageRange, String gender, String nickname,
-                  String phoneNumber, RoleType roleType, Long visitsCount, LocalDateTime createdAt, LocalDateTime lastLoginAt) {
+                  String phoneNumber, RoleType roleType, Long visitsCount) {
         this.email = email;
         this.password = password;
         this.OAuthProvider = OAuthProvider;
@@ -68,12 +74,9 @@ public class Member {
         this.phoneNumber = phoneNumber;
         this.roleType = roleType;
         this.visitsCount = visitsCount;
-        this.createdAt = createdAt;
-        this.lastLoginAt = lastLoginAt;
     }
 
     public static Member of(JwtVo.Body body) {
-        LocalDateTime now = LocalDateTime.now();
         return Member.builder()
                 .email(body.getEmail())
 //                .password()
@@ -88,8 +91,6 @@ public class Member {
                 .phoneNumber(body.getPhoneNumber())
                 .roleType(RoleType.USER)
                 .visitsCount(1L)
-                .createdAt(now)
-                .lastLoginAt(now)
                 .build();
     }
 }

--- a/backend/src/main/java/com/bootme/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/bootme/member/repository/MemberRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -18,13 +17,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Modifying
     @Transactional
-    @Query("UPDATE Member m SET m.lastLoginAt = :lastLoginAt WHERE m.email = :email")
-    int updateLastLoginTime(@Param("email") String email, @Param("lastLoginAt") LocalDateTime lastLoginAt);
-
-    @Modifying
-    @Transactional
-    @Query("UPDATE Member m SET m.visitsCount = m.visitsCount + 1 WHERE m.email = :email")
+    @Query("UPDATE Member m SET m.visitsCount = m.visitsCount + 1, m.modifiedAt = CURRENT_TIMESTAMP WHERE m.email = :email")
     int incrementVisits(@Param("email") String email);
 
 }
-


### PR DESCRIPTION
### Member 엔티티 클래스에 `@CreatedDate`, `@LastModifiedDate` 적용

- 기존에는 아래와 같이 현재 시각을 직접 생성해서 필드에 입력했음
  - `LocalDateTime now = LocalDateTime.now();`
- `@CreatedDate`, `@LastModifiedDate` 사용으로 튜플 생성시 현재 시각이 자동으로 입력되고, 튜플 수정시에도 자동으로 수정 시간이 입력되도록 변경

<br>

### 마지막 로그인 시각 업데이트 하는 로직 삭제
- 가입된 유저가 로그인하면 해당 멤버 튜플에 마지막 로그인 시각 업데이트 하는 로직 삭제
- Member 엔티티 클래스에서 @LastModifiedDate 사용하기 때문에 수동으로 마지막 로그인 시각을 업데이트 하는 로직 필요 없어졌기 때문에 삭제

<br>

***

close #130 







