### PR TITLE
[FE] useLogin 커스텀 훅의 isLogin 값으로 로그인 상태 관리

### DIFF
--- a/frontend/src/api/fetcher/index.tsx
+++ b/frontend/src/api/fetcher/index.tsx
@@ -11,22 +11,3 @@ export const noCredentialsFetcher = axios.create({
 });
 
 axios.defaults.withCredentials = true;
-
-/**
- * 서버 응답에 `Login` 헤더 있으면 `Login` 헤더를 localStorage 에 저장함
- * */
-fetcher.interceptors.response.use(response => {
-  const loginHeaderValue = response.headers['login'];
-  if (loginHeaderValue) {
-    localStorage.setItem('Login', loginHeaderValue);
-  }
-  return response;
-});
-
-noCredentialsFetcher.interceptors.response.use(response => {
-  const loginHeaderValue = response.headers['login'];
-  if (loginHeaderValue) {
-    localStorage.setItem('Login', loginHeaderValue);
-  }
-  return response;
-});

--- a/frontend/src/components/Header/MenuModal/index.tsx
+++ b/frontend/src/components/Header/MenuModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import ReactModal from 'react-modal';
 import { Button } from 'antd';
 import GitHubIcon from '../../../assets/github.svg';
@@ -21,14 +21,9 @@ import {
 } from './style';
 import { CloseIconBlack, CloseIconGray } from '../../../constants/icons';
 import { useLogin } from '../../../hooks/useLogin';
-const MenuModal = ({ isMenuOpen, setIsMenuOpen, nickName, profileImage }: MenuModalProps) => {
+const MenuModal = ({ isLogin, isMenuOpen, setIsMenuOpen, nickName, profileImage }: MenuModalProps) => {
   const [isHovered, setIsHovered] = useState(false);
-  const [isLogin, setIsLogin] = useState(JSON.parse(localStorage.getItem('Login') || 'false'));
   const { handleLogOut, handleLoginModal } = useLogin();
-
-  useEffect(() => {
-    setIsLogin(JSON.parse(localStorage.getItem('Login') || 'false'));
-  }, [localStorage.getItem('Login')]);
 
   return (
     <ReactModal
@@ -127,6 +122,7 @@ const MenuModal = ({ isMenuOpen, setIsMenuOpen, nickName, profileImage }: MenuMo
 export default MenuModal;
 
 interface MenuModalProps {
+  isLogin: boolean;
   isMenuOpen: boolean;
   setIsMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
   profileImage: string | null;

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -24,15 +24,10 @@ import UserDropDown from './UserDropDown';
 import MenuModal from './MenuModal';
 
 const Header = () => {
-  const { handleLoginModal } = useLogin();
-  const [isLogin, setIsLogin] = useState(JSON.parse(localStorage.getItem('Login') || 'false'));
+  const { isLogin, handleLoginModal } = useLogin();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [profileImage, setProfileImage] = useState(localStorage.getItem('ProfileImage'));
   const [nickName, setNickName] = useState(localStorage.getItem('NickName'));
-
-  useEffect(() => {
-    setIsLogin(JSON.parse(localStorage.getItem('Login') || 'false'));
-  }, [localStorage.getItem('Login')]);
 
   useEffect(() => {
     setNickName(localStorage.getItem('NickName'));
@@ -48,6 +43,7 @@ const Header = () => {
       <Layout>
         <Wrapper>
           <HeaderLeft>
+            <div onClick={() => console.log(isLogin)}>isLogin</div>
             <Logo>
               <GitHubIcon />
               <ServiceName>BootMe</ServiceName>
@@ -98,6 +94,7 @@ const Header = () => {
       </Layout>
       <LoginModal />
       <MenuModal
+        isLogin={isLogin}
         isMenuOpen={isMenuOpen}
         setIsMenuOpen={setIsMenuOpen}
         profileImage={profileImage}

--- a/frontend/src/components/LoginModal/GoogleLogin/index.tsx
+++ b/frontend/src/components/LoginModal/GoogleLogin/index.tsx
@@ -3,21 +3,13 @@ import { useGoogleOneTapLogin } from '@react-oauth/google';
 import { useLogin } from '../../../hooks/useLogin';
 
 export const GoogleLoginButton = () => {
-  const { sendIdTokenToServer } = useLogin();
+  const { sendIdTokenToServer, handleLoginSuccess } = useLogin();
   return (
     <GoogleLogin
       onSuccess={credentialResponse => {
-        console.log(
-          '< Google Login > \n\nclientId: ' +
-            credentialResponse.clientId +
-            '\n\ncredential: ' +
-            credentialResponse.credential
-        );
-        console.log('---- 구글 로그인 응답 ----');
-        console.log(credentialResponse);
-        console.log('----------------------');
-        const idToken = credentialResponse.credential;
-        sendIdTokenToServer(idToken);
+        sendIdTokenToServer(credentialResponse.credential).then(() => {
+          handleLoginSuccess('google');
+        });
       }}
       onError={() => {
         alert('구글 로그인 실패');
@@ -31,18 +23,13 @@ export const GoogleLoginButton = () => {
 };
 
 export const GoogleLoginOneTap = () => {
-  const { sendIdTokenToServer } = useLogin();
+  const { sendIdTokenToServer, handleLoginSuccess } = useLogin();
 
   useGoogleOneTapLogin({
     onSuccess: credentialResponse => {
-      console.log(
-        '< Google One Tap Login > \n\nclientId: ' +
-          credentialResponse.clientId +
-          '\n\ncredential: ' +
-          credentialResponse.credential
-      );
-      const idToken = credentialResponse.credential;
-      sendIdTokenToServer(idToken);
+      sendIdTokenToServer(credentialResponse.credential).then(() => {
+        handleLoginSuccess('google');
+      });
     },
     onError: () => {
       alert('구글 로그인 실패');

--- a/frontend/src/components/LoginModal/KakaoLogin/index.tsx
+++ b/frontend/src/components/LoginModal/KakaoLogin/index.tsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import qs from 'qs';
 import LoginButton from '../LoginButton';
 import { useLogin } from '../../../hooks/useLogin';
-import { useNavigate } from 'react-router-dom';
 import { noCredentialsFetcher } from '../../../api/fetcher';
 
 const REST_API_KEY = process.env.REACT_APP_KAKAO_API_KEY;
@@ -46,8 +45,7 @@ export const KakaoLogin = () => {
         console.log(error);
       });
   };
-  const { sendIdTokenToServer } = useLogin();
-  const navigate = useNavigate();
+  const { sendIdTokenToServer, handleLoginSuccess } = useLogin();
 
   /**
    *  1. KakaoLoginButton: 카카오 인증 서버로 Access Token 받기를 요청하면, 카카오 인증 서버가 사용자에게 카카오계정 로그인을 통한 인증을 요청
@@ -59,8 +57,7 @@ export const KakaoLogin = () => {
   useEffect(() => {
     sendAccessTokenToKakao().then(idToken =>
       sendIdTokenToServer(idToken).then(() => {
-        localStorage.setItem('Login', 'true');
-        navigate(-1);
+        handleLoginSuccess('kakao');
       })
     );
   }, []);

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -13,18 +13,18 @@ const rootElement = document.getElementById('root') as Element;
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(rootElement).render(
-  <GoogleOAuthProvider clientId={process.env.REACT_APP_GOOGLE_CLIENT_ID as string}>
+  <BrowserRouter>
     <LoginProvider>
-      <FilterProvider>
-        <BrowserRouter>
+      <GoogleOAuthProvider clientId={process.env.REACT_APP_GOOGLE_CLIENT_ID as string}>
+        <FilterProvider>
           <QueryClientProvider client={queryClient}>
             <ThemeProvider theme={theme}>
               <GlobalStyle />
               <App />
             </ThemeProvider>
           </QueryClientProvider>
-        </BrowserRouter>
-      </FilterProvider>
+        </FilterProvider>
+      </GoogleOAuthProvider>
     </LoginProvider>
-  </GoogleOAuthProvider>
+  </BrowserRouter>
 );


### PR DESCRIPTION
- 기존에 로컬 스토리지에 Login 값을 저장하고 해당 값으로 로그인 상태를 관리했으나 다음과 같은 번거로움 있음
  - 로컬스토리지에 저장된 Login 값을 지속적으로 가져와서 확인하는 코드 필요함
  - useEffect로 로컬스토리지의 Login 값을 지속적으로 가져오려고 시도하면 오류가 많이 발생함

- useLogin 커스텀 훅의 `isLogin` 값으로 로그인 상태를 관리하는 것으로 변경

***

close #136 







