### PR TITLE
[BE] CascadeType.PERSIST 설정과 관련하여 발생한 테스트 오류 해결

### DIFF
--- a/backend/src/main/java/com/bootme/course/service/CompanyService.java
+++ b/backend/src/main/java/com/bootme/course/service/CompanyService.java
@@ -5,6 +5,7 @@ import com.bootme.course.dto.CompanyRequest;
 import com.bootme.course.dto.CompanyResponse;
 import com.bootme.course.exception.CompanyNotFoundException;
 import com.bootme.course.repository.CompanyRepository;
+import com.bootme.course.repository.CourseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,7 @@ import static com.bootme.common.exception.ErrorType.NOT_FOUND_COMPANY;
 public class CompanyService {
 
     private final CompanyRepository companyRepository;
+    private final CourseRepository courseRepository;
 
     public Long addCompany(CompanyRequest companyRequest){
         Company company = Company.builder()
@@ -52,7 +54,10 @@ public class CompanyService {
     }
 
     public void deleteCompany(Long companyId){
-        companyRepository.deleteById(companyId);
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new CompanyNotFoundException(NOT_FOUND_COMPANY));
+        courseRepository.deleteAll(company.getCourses());
+        companyRepository.delete(company);
     }
 
 }

--- a/backend/src/test/java/com/bootme/course/service/CompanyServiceTest.java
+++ b/backend/src/test/java/com/bootme/course/service/CompanyServiceTest.java
@@ -1,6 +1,7 @@
 package com.bootme.course.service;
 
 import com.bootme.course.domain.Company;
+import com.bootme.course.domain.Course;
 import com.bootme.course.dto.CompanyResponse;
 import com.bootme.course.exception.CompanyNotFoundException;
 import com.bootme.course.repository.CompanyRepository;
@@ -33,6 +34,12 @@ class CompanyServiceTest extends ServiceTest {
     public void setUp() {
         company1 = getCompany(1);
         company2 = getCompany(2);
+        Course course1 = getCourse(1);
+        Course course2 = getCourse(2);
+        Course course3 = getCourse(3);
+        company1.addCourse(course1);
+        company1.addCourse(course2);
+        company2.addCourse(course3);
     }
 
     @Test

--- a/backend/src/test/java/com/bootme/course/service/CourseServiceTest.java
+++ b/backend/src/test/java/com/bootme/course/service/CourseServiceTest.java
@@ -45,6 +45,7 @@ class CourseServiceTest extends ServiceTest {
         companyRepository.save(company2);
         companyRepository.save(company3);
         course = getCourse(1);
+        company1.addCourse(course);
     }
 
     @Test
@@ -54,23 +55,23 @@ class CourseServiceTest extends ServiceTest {
         long count = courseRepository.count();
 
         //when
-        Long id = courseService.addCourse(getCourseRequest(1));
+        Long id = courseService.addCourse(getCourseRequest(2));
         Course foundCourse = courseRepository.findById(id)
                 .orElseThrow(() -> new CourseNotFoundException(NOT_FOUND_COURSE));
 
         //then
         assertAll(
                 () -> assertThat(courseRepository.count()).isEqualTo(count + 1),
-                () -> assertThat(foundCourse.getTitle()).isEqualTo(VALID_TITLE_1),
-                () -> assertThat(foundCourse.getUrl()).isEqualTo(VALID_URL_1),
-                () -> assertThat(foundCourse.getCompany().getName()).isEqualTo(getCompany(1).getName()),
-                () -> assertThat(foundCourse.getLocation()).isEqualTo(VALID_LOCATION_1),
-                () -> assertThat(foundCourse.getCost()).isEqualTo(VALID_COST_1),
-                () -> assertThat(foundCourse.getCostType()).isEqualTo(VALID_CostType_1),
-                () -> assertThat(foundCourse.getDates()).isEqualTo(VALID_DATES_1),
-                () -> assertThat(foundCourse.getOnoffline()).isEqualTo(VALID_ONOFFLINE_1),
+                () -> assertThat(foundCourse.getTitle()).isEqualTo(VALID_TITLE_2),
+                () -> assertThat(foundCourse.getUrl()).isEqualTo(VALID_URL_2),
+                () -> assertThat(foundCourse.getCompany().getName()).isEqualTo(getCompany(2).getName()),
+                () -> assertThat(foundCourse.getLocation()).isEqualTo(VALID_LOCATION_2),
+                () -> assertThat(foundCourse.getCost()).isEqualTo(VALID_COST_2),
+                () -> assertThat(foundCourse.getCostType()).isEqualTo(VALID_CostType_2),
+                () -> assertThat(foundCourse.getDates()).isEqualTo(VALID_DATES_2),
+                () -> assertThat(foundCourse.getOnoffline()).isEqualTo(VALID_ONOFFLINE_2),
                 // repository 에서 찾아온 리스트는 persistenceBag 에 담겨있기 때문에 아래와 같이 검증
-                () -> assertThat(foundCourse.getPrerequisites()).isEqualTo(VALID_PREREQUISITES_1)
+                () -> assertThat(foundCourse.getPrerequisites()).isEqualTo(VALID_PREREQUISITES_2)
         );
     }
 
@@ -97,14 +98,13 @@ class CourseServiceTest extends ServiceTest {
     @DisplayName("findAll()은 모든 코스 정보를 반환한다.")
     public void findAll (){
         //given
-        courseService.addCourse(getCourseRequest(1));
         courseService.addCourse(getCourseRequest(2));
         courseService.addCourse(getCourseRequest(3));
 
         //when
         List<CourseResponse> courseResponses = courseService.findAll();
 
-        //then
+        //then: setUp()의 company1.addCourse(course)에서 코스 한 개 등록되었으므로 총 3개의 코스
         assertThat(courseResponses.size()).isEqualTo(3);
     }
 

--- a/backend/src/test/java/com/bootme/util/fixture/CourseFixture.java
+++ b/backend/src/test/java/com/bootme/util/fixture/CourseFixture.java
@@ -240,11 +240,7 @@ public class CourseFixture {
         String[] urls = {VALID_COM_URL_1, VALID_COM_URL_2, VALID_COM_URL_3};
         String[] serviceUrls = {VALID_COM_SERVICE_URL_1, VALID_COM_SERVICE_URL_2, VALID_COM_SERVICE_URL_3};
         String[] logoUrls = {VALID_COM_LOGO_URL_1, VALID_COM_LOGO_URL_2, VALID_COM_LOGO_URL_3};
-        List[] courses = new ArrayList[]{
-                new ArrayList<>(Arrays.asList(getCourses()[0], getCourses()[1], getCourses()[2])),
-                new ArrayList<>(Arrays.asList(getCourses()[0], getCourses()[1], getCourses()[2])),
-                new ArrayList<>(Arrays.asList(getCourses()[0], getCourses()[1], getCourses()[2])),
-        };
+        List<Course> courses = new ArrayList<>();
 
         return Company.builder()
                 .name(names[index])
@@ -252,7 +248,7 @@ public class CourseFixture {
                 .url(urls[index])
                 .serviceUrl(serviceUrls[index])
                 .logoUrl(logoUrls[index])
-                .courses(courses[index])
+                .courses(courses)
                 .build();
     }
 


### PR DESCRIPTION
https://github.com/Jinwook94/bootme/commit/31c5ec43e4aac612748efd5b5a874772b608f3fc 에서 **CascadeType.PERSIST** 관련 변경사항이 있었는데, 해당 변경으로 인해 테스트 코드에서 오류 발생함
  - <img width="308" alt="image" src="https://user-images.githubusercontent.com/44575214/219407570-b325e25b-04c2-4819-9314-e85da901a174.png">

<br>

### 문제: Company 인스턴스 영속화 전에 Course 인스턴스 영속화

```java
class CompanyServiceTest extends ServiceTest {
	...
	public void setUp() {
	    company1 = getCompany(1);
	    company2 = getCompany(2);
	}
	...
}

public class CourseFixture {
	...
	
	public static Company getCompany(int index) {
  ...
    List[] courses = new ArrayList[]{
            new ArrayList<>(Arrays.asList(getCourses()[0], getCourses()[1], getCourses()[2])),
            new ArrayList<>(Arrays.asList(getCourses()[0], getCourses()[1], getCourses()[2])),
            new ArrayList<>(Arrays.asList(getCourses()[0], getCourses()[1], getCourses()[2])),
    };
	...
	}

}
```

- `CompanyServiceTest.setUp()`  에서는 `Company` 인스턴스를 생성하는 static 팩토리 메서드를 사용하는데, 해당 메서드에서 동시에 `Course` 인스턴스로 생성하여 `Company` 인스턴스에 넣어줌
- 이 상태에서 `companyRepository.save(company1);` 를 호출하면 `Company` 인스턴스와 `Course` 인스턴스를 동시에 persist 하게 됨
- 그러나 `cascade = CascadeType.*PERSIST`* 설정 때문에 Course 인스턴스는 그것이 참조하는 Company 인스턴스가 먼저 persist 된 후에 persist 되어야함
- 그렇기 때문에 예외 발생함
    - *org.hibernate.**TransientPropertyValueException**: object references an unsaved transient instance - **save the transient instance before flushing** : com.bootme.course.domain.Course.company -> com.bootme.course.domain.Company;*
    

### 해결

- CourseFixture.getCompany() 에서 Company 인스턴스 생성시 Course 인스턴스는 생성하지 않게 변경
- <img width="464" alt="image" src="https://user-images.githubusercontent.com/44575214/219419791-d69366b9-ee42-487e-997e-a3785f164080.png">



***

close #141 