### PR TITLE
[BE] ID 토큰 검증 구현 - 3. IssuedAt 검증 

### DIFF
--- a/backend/src/main/java/com/bootme/auth/exception/InvalidIssuedAtException.java
+++ b/backend/src/main/java/com/bootme/auth/exception/InvalidIssuedAtException.java
@@ -1,0 +1,12 @@
+package com.bootme.auth.exception;
+
+import com.bootme.common.exception.ErrorType;
+import com.bootme.common.exception.UnauthorizedException;
+
+public class InvalidIssuedAtException extends UnauthorizedException {
+
+    public InvalidIssuedAtException(final ErrorType errorType, final String issuer) {
+        super(errorType, issuer);
+    }
+
+}

--- a/backend/src/main/java/com/bootme/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/bootme/common/exception/ErrorType.java
@@ -17,6 +17,7 @@ public enum ErrorType {
     FORBIDDEN_REQUEST       (FORBIDDEN,    1004, "권한이 없습니다."),
     INVALID_ISSUER          (UNAUTHORIZED, 1005, "유효하지 않은 토큰 발급자입니다."),
     INVALID_AUDIENCE        (UNAUTHORIZED, 1006, "토큰의 Audience 값이 유효하지 않습니다."),
+    INVALID_ISSUED_AT        (UNAUTHORIZED, 1007, "토큰의 발행시간이 올바르지 않습니다. "),
 
     NOT_FOUND_COURSE        (BAD_REQUEST,  3001, "존재하지 않는 코스입니다."),
 

--- a/backend/src/test/java/com/bootme/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/bootme/auth/service/AuthServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.bootme.auth.dto.JwtVo;
 import com.bootme.auth.exception.InvalidAudienceException;
+import com.bootme.auth.exception.InvalidIssuedAtException;
 import com.bootme.auth.exception.InvalidIssuerException;
 import com.bootme.util.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
@@ -50,18 +51,26 @@ class AuthServiceTest extends ServiceTest {
         );
     }
 
-    @DisplayName("verifyIssuer()는 ID 토큰의 발행자가 유효하지 않을 경우 예외를 발생시킨다.")
+    @DisplayName("verifyIssuer()는 ID 토큰의 iss 값이 유효하지 않을 경우 예외를 발생시킨다.")
     @Test
     void verifyToken_verifyIssuer() {
         JwtVo jwtVo = getJwtVo("https://invalid.issuer.com", validGoogleAud);
         assertThrows(InvalidIssuerException.class, () -> authService.verifyToken(jwtVo));
     }
 
-    @DisplayName("verifyAudience()는 ID 토큰 Audience 값이 유효하지 않을 경우 예외를 발생시킨다.")
+    @DisplayName("verifyAudience()는 ID 토큰의 aud 값이 유효하지 않을 경우 예외를 발생시킨다.")
     @Test
     void verifyToken_verifyAudience(){
         JwtVo jwtVo = getJwtVo(validGoogleIss, "invalidAudience");
         assertThrows(InvalidAudienceException.class, () -> authService.verifyToken(jwtVo));
+    }
+
+    @DisplayName("verifyIssuedAt()은 ID 토큰의 iat 값이 유효하지 않을 경우 예외를 발생시킨다.")
+    @Test
+    void verifyToken_verifyIssuedAt(){
+        // 발행 시간이 미래인 토큰
+        JwtVo jwtVo = getJwtVo(validGoogleIss, validGoogleAud, 2524608000L);
+        assertThrows(InvalidIssuedAtException.class, () -> authService.verifyToken(jwtVo));
     }
 
 }

--- a/backend/src/test/java/com/bootme/util/fixture/AuthFixture.java
+++ b/backend/src/test/java/com/bootme/util/fixture/AuthFixture.java
@@ -23,4 +23,15 @@ public class AuthFixture {
         return new JwtVo(VALID_JWT_HEADER, body);
     }
 
+    public static JwtVo getJwtVo(String issuer, String audience, Long issuedAt){
+        JwtVo.Body body = JwtVo.Body.builder()
+                .iss(issuer)
+                .aud(audience)
+                .iat(issuedAt)
+                .exp(VALID_EXP)
+                .email(VALID_EMAIL)
+                .build();
+        return new JwtVo(VALID_JWT_HEADER, body);
+    }
+
 }


### PR DESCRIPTION
### ID 토큰 iat(IssuedAt) 검증 메서드
```java
    private void verifyIssuedAt(JwtVo.Body body){
        long iat = body.getIat();
        long now = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC);
        long clockSkewTolerance = 300;

        if (iat > (now + clockSkewTolerance)) {
            throw new InvalidIssuedAtException(INVALID_ISSUED_AT, String.valueOf(iat));
        }
    }
```
> When verifying the iat claim, it is important to take into account the possibility of clock skew between the issuer and the verifier systems. Clock skew refers to the difference in time between the clocks of different systems, which can cause the iat claim to be slightly off from the current time on the verifier system.
>
- clockSkewTolerance = 5분 (300초)

<br>

### 단위 테스트
```java
    @DisplayName("verifyIssuedAt()은 ID 토큰의 iat 값이 유효하지 않을 경우 예외를 발생시킨다.")
    @Test
    void verifyToken_verifyIssuedAt(){
        // 발행 시간이 미래인 토큰
        JwtVo jwtVo = getJwtVo(validGoogleIss, validGoogleAud, 2524608000L);
        assertThrows(InvalidIssuedAtException.class, () -> authService.verifyToken(jwtVo));
    }
```

<br>


***

close #145