### PR TITLE
[BE] ID 토큰 검증 구현 - 4. Expiration Time 검증

### DIFF
--- a/backend/src/main/java/com/bootme/auth/exception/TokenExpiredException.java
+++ b/backend/src/main/java/com/bootme/auth/exception/TokenExpiredException.java
@@ -1,0 +1,12 @@
+package com.bootme.auth.exception;
+
+import com.bootme.common.exception.ErrorType;
+import com.bootme.common.exception.UnauthorizedException;
+
+public class TokenExpiredException extends UnauthorizedException {
+
+    public TokenExpiredException(final ErrorType errorType, final String issuer) {
+        super(errorType, issuer);
+    }
+
+}

--- a/backend/src/main/java/com/bootme/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/bootme/common/exception/ErrorType.java
@@ -17,7 +17,8 @@ public enum ErrorType {
     FORBIDDEN_REQUEST       (FORBIDDEN,    1004, "권한이 없습니다."),
     INVALID_ISSUER          (UNAUTHORIZED, 1005, "유효하지 않은 토큰 발급자입니다."),
     INVALID_AUDIENCE        (UNAUTHORIZED, 1006, "토큰의 Audience 값이 유효하지 않습니다."),
-    INVALID_ISSUED_AT        (UNAUTHORIZED, 1007, "토큰의 발행시간이 올바르지 않습니다. "),
+    INVALID_ISSUED_AT       (UNAUTHORIZED, 1007, "토큰의 발행시간이 올바르지 않습니다. "),
+    TOKEN_EXPIRED           (UNAUTHORIZED, 1008, "토큰이 만료되었습니다. "),
 
     NOT_FOUND_COURSE        (BAD_REQUEST,  3001, "존재하지 않는 코스입니다."),
 

--- a/backend/src/test/java/com/bootme/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/bootme/auth/service/AuthServiceTest.java
@@ -7,6 +7,7 @@ import com.bootme.auth.dto.JwtVo;
 import com.bootme.auth.exception.InvalidAudienceException;
 import com.bootme.auth.exception.InvalidIssuedAtException;
 import com.bootme.auth.exception.InvalidIssuerException;
+import com.bootme.auth.exception.TokenExpiredException;
 import com.bootme.util.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,6 +72,14 @@ class AuthServiceTest extends ServiceTest {
         // 발행 시간이 미래인 토큰
         JwtVo jwtVo = getJwtVo(validGoogleIss, validGoogleAud, 2524608000L);
         assertThrows(InvalidIssuedAtException.class, () -> authService.verifyToken(jwtVo));
+    }
+
+    @DisplayName("verifyExpiration()은 ID 토큰의 exp 값이 유효하지 않을 경우 예외를 발생시킨다.")
+    @Test
+    void verifyToken_verifyExpiration(){
+        // 만료 된 토큰 (exp: 23-02-17 00:00:00 GMT+0900)
+        JwtVo jwtVo = getJwtVo_exp(validGoogleIss, validGoogleAud, 1676559600L);
+        assertThrows(TokenExpiredException.class, () -> authService.verifyToken(jwtVo));
     }
 
 }

--- a/backend/src/test/java/com/bootme/util/fixture/AuthFixture.java
+++ b/backend/src/test/java/com/bootme/util/fixture/AuthFixture.java
@@ -9,7 +9,7 @@ public class AuthFixture {
                                                             .typ("JWT")
                                                             .build();
     public static final Long VALID_IAT = 1675313707L;
-    public static final Long VALID_EXP = 1675313707L;
+    public static final Long VALID_EXP = 2524608000L;
     public static final String VALID_EMAIL = "valid@email.com";
 
     public static JwtVo getJwtVo(String issuer, String audience){
@@ -29,6 +29,17 @@ public class AuthFixture {
                 .aud(audience)
                 .iat(issuedAt)
                 .exp(VALID_EXP)
+                .email(VALID_EMAIL)
+                .build();
+        return new JwtVo(VALID_JWT_HEADER, body);
+    }
+
+    public static JwtVo getJwtVo_exp(String issuer, String audience, Long expirationTime){
+        JwtVo.Body body = JwtVo.Body.builder()
+                .iss(issuer)
+                .aud(audience)
+                .iat(VALID_IAT)
+                .exp(expirationTime)
                 .email(VALID_EMAIL)
                 .build();
         return new JwtVo(VALID_JWT_HEADER, body);


### PR DESCRIPTION
### ID 토큰 iat(IssuedAt) 검증 메서드
```java
    private void verifyExpiration(JwtVo.Body body) {
        long exp = body.getExp();
        long now = Instant.now().getEpochSecond();
        long clockSkewTolerance = 300;

        if (exp < (now - clockSkewTolerance)) {
            throw new TokenExpiredException(TOKEN_EXPIRED, String.valueOf(exp));
        }
    }
```
> When verifying the iat claim, it is important to take into account the possibility of clock skew between the issuer and the verifier systems. Clock skew refers to the difference in time between the clocks of different systems, which can cause the iat claim to be slightly off from the current time on the verifier system.
>
- clockSkewTolerance = 5분 (300초)

<br>

### 단위 테스트
```java
    @DisplayName("verifyExpiration()은 ID 토큰의 exp 값이 유효하지 않을 경우 예외를 발생시킨다.")
    @Test
    void verifyToken_verifyExpiration(){
        // 만료 된 토큰 (exp: 23-02-17 00:00:00 GMT+0900)
        JwtVo jwtVo = getJwtVo_exp(validGoogleIss, validGoogleAud, 1676559600L);
        assertThrows(TokenExpiredException.class, () -> authService.verifyToken(jwtVo));
    }

```

<br>


***

close #147