### PR TITLE
[BE] GoogleIdTokenVerifier 클래스를 싱글톤으로 변경

### DIFF
--- a/backend/src/main/java/com/bootme/auth/service/AuthService.java
+++ b/backend/src/main/java/com/bootme/auth/service/AuthService.java
@@ -14,8 +14,6 @@ import com.bootme.member.repository.MemberRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
-import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.client.http.javanet.NetHttpTransport;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,9 +25,9 @@ import java.security.GeneralSecurityException;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Objects;
 
+import static com.bootme.auth.token.GoogleIdTokenVerifierSingleton.getVerifier;
 import static com.bootme.common.exception.ErrorType.*;
 
 
@@ -160,11 +158,7 @@ public class AuthService {
     }
 
     private void verifyGoogleSignature(String idToken) throws GeneralSecurityException, IOException {
-        JacksonFactory jacksonFactory = new JacksonFactory();
-        GoogleIdTokenVerifier verifier =
-                new GoogleIdTokenVerifier.Builder((new NetHttpTransport()), jacksonFactory)
-                        .setAudience(Collections.singletonList(googleAud))
-                        .build();
+        GoogleIdTokenVerifier verifier = getVerifier(googleAud);
 
         // Signature 정상이면 ID Token 반환, 비정상이면 null 반환함
         GoogleIdToken returnedIdToken = verifier.verify(idToken);

--- a/backend/src/main/java/com/bootme/auth/token/GoogleIdTokenVerifierSingleton.java
+++ b/backend/src/main/java/com/bootme/auth/token/GoogleIdTokenVerifierSingleton.java
@@ -1,0 +1,27 @@
+package com.bootme.auth.token;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
+import java.util.Collections;
+
+public class GoogleIdTokenVerifierSingleton {
+    private static GoogleIdTokenVerifier verifier = null;
+
+    private GoogleIdTokenVerifierSingleton() {}
+
+    public static synchronized GoogleIdTokenVerifier getVerifier(String googleAud) {
+        if (verifier == null) {
+            HttpTransport transport = new NetHttpTransport();
+            JsonFactory jsonFactory = new JacksonFactory();
+
+            verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
+                            .setAudience(Collections.singletonList(googleAud))
+                            .build();
+        }
+        return verifier;
+    }
+}


### PR DESCRIPTION
## GoogleIdTokenVerifier 클래스 싱글톤 구현


```java
public class GoogleIdTokenVerifierSingleton {
    private static GoogleIdTokenVerifier verifier = null;

    private GoogleIdTokenVerifierSingleton() {}

    public static synchronized GoogleIdTokenVerifier getVerifier(String googleAud) {
        if (verifier == null) {
            HttpTransport transport = new NetHttpTransport();
            JsonFactory jsonFactory = new JacksonFactory();

            verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
                            .setAudience(Collections.singletonList(googleAud))
                            .build();
        }
        return verifier;
    }
}
```

<br>

> Use the constructor `GoogleIdTokenVerifier(HttpTransport, JsonFactory)` for the typical simpler case if your application has only a single instance of `GoogleIdTokenVerifier`.
[Class GoogleIdTokenVerifier (2.1.2)](https://cloud.google.com/java/docs/reference/google-api-client/latest/com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier#:~:text=Use%20the%20constructor%20%23GoogleIdTokenVerifier(HttpTransport%2C%20JsonFactory)%20for%20the%20typical%20simpler%20case%20if%20your%20application%20has%20only%20a%20single%20instance%20of%20GoogleIdTokenVerifier)
>


- 공식 문서에 `GoogleIdTokenVerifier` 인스턴스가 하나만 있는 경우에 `GoogleIdTokenVerifier(HttpTransport, JsonFactory)` 생성자를 사용하는 것을 권장하기 때문에 `GoogleIdTokenVerifier` 클래스를 싱글톤으로 변경함
- 카카오 로그인의 공개키 프로바이더를 싱글톤으로 구현해야 하는 것과 같은 맥락일듯함
  - [참고](https://kakao-tam.tistory.com/130#:~:text=%EC%A3%BC%EC%9D%98!%20%EA%B3%B5%EA%B0%9C%ED%82%A4%20%ED%94%84%EB%A1%9C%EB%B0%94%EC%9D%B4%EB%8D%94%EB%8A%94%20%EB%B0%98%EB%93%9C%EC%8B%9C%20%EC%8B%B1%EA%B8%80%ED%86%A4%20%EA%B0%9D%EC%B1%84%EB%A1%9C%20%EA%B5%AC%ED%98%84%20%ED%95%98%EC%8B%AD%EC%8B%9C%EC%98%A4.)




***

close #







