### PR TITLE
[BE] ID 토큰 검증 메서드의 단위 테스트 작성

### DIFF
--- a/backend/src/test/java/com/bootme/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/bootme/auth/service/AuthServiceTest.java
@@ -1,85 +1,57 @@
-//package com.bootme.auth.service;
-//
-//import static com.bootme.util.fixture.AuthFixture.*;
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//import com.bootme.auth.dto.JwtVo;
-//import com.bootme.auth.exception.InvalidAudienceException;
-//import com.bootme.auth.exception.InvalidIssuedAtException;
-//import com.bootme.auth.exception.InvalidIssuerException;
-//import com.bootme.auth.exception.TokenExpiredException;
-//import com.bootme.util.ServiceTest;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.beans.factory.annotation.Value;
-//
-//@DisplayName("AuthService 클래스의")
-//class AuthServiceTest extends ServiceTest {
-//
-//    @Autowired
-//    private AuthService authService;
-//
-//    @Value("${security.jwt.google.issuer}")
-//    private String validGoogleIss;
-//
-//    @Value("${security.jwt.naver.issuer}")
-//    private String validNaverIss;
-//
-//    @Value("${security.jwt.kakao.issuer}")
-//    private String validKakaoIss;
-//
-//    @Value("${security.jwt.google.audience}")
-//    private String validGoogleAud;
-//
-//    @Value("${security.jwt.naver.audience}")
-//    private String validNaverAud;
-//
-//    @Value("${security.jwt.kakao.audience}")
-//    private String validKakaoAud;
-//
-//    @DisplayName("verifyToken()은 ID 토큰이 유효한 경우 예외를 발생시키지 않는다.")
-//    @Test
-//    void verifyToken() {
-//        JwtVo jwtVoGoogle = getJwtVo(validGoogleIss, validGoogleAud);
-//        JwtVo jwtVoNaver = getJwtVo(validNaverIss, validNaverAud);
-//        JwtVo jwtVoKakao = getJwtVo(validKakaoIss, validKakaoAud);
-//
-//        assertAll(
-//                () -> assertDoesNotThrow(() -> authService.verifyToken(jwtVoGoogle)),
-//                () -> assertDoesNotThrow(() -> authService.verifyToken(jwtVoNaver)),
-//                () -> assertDoesNotThrow(() -> authService.verifyToken(jwtVoKakao))
-//        );
-//    }
-//
-//    @DisplayName("verifyIssuer()는 ID 토큰의 iss 값이 유효하지 않을 경우 예외를 발생시킨다.")
-//    @Test
-//    void verifyToken_verifyIssuer() {
-//        JwtVo jwtVo = getJwtVo("https://invalid.issuer.com", validGoogleAud);
-//        assertThrows(InvalidIssuerException.class, () -> authService.verifyToken(jwtVo));
-//    }
-//
-//    @DisplayName("verifyAudience()는 ID 토큰의 aud 값이 유효하지 않을 경우 예외를 발생시킨다.")
-//    @Test
-//    void verifyToken_verifyAudience(){
-//        JwtVo jwtVo = getJwtVo(validGoogleIss, "invalidAudience");
-//        assertThrows(InvalidAudienceException.class, () -> authService.verifyToken(jwtVo));
-//    }
-//
-//    @DisplayName("verifyIssuedAt()은 ID 토큰의 iat 값이 유효하지 않을 경우 예외를 발생시킨다.")
-//    @Test
-//    void verifyToken_verifyIssuedAt(){
-//        // 발행 시간이 미래인 토큰
-//        JwtVo jwtVo = getJwtVo(validGoogleIss, validGoogleAud, 2524608000L);
-//        assertThrows(InvalidIssuedAtException.class, () -> authService.verifyToken(jwtVo));
-//    }
-//
-//    @DisplayName("verifyExpiration()은 ID 토큰의 exp 값이 유효하지 않을 경우 예외를 발생시킨다.")
-//    @Test
-//    void verifyToken_verifyExpiration(){
-//        // 만료 된 토큰 (exp: 23-02-17 00:00:00 GMT+0900)
-//        JwtVo jwtVo = getJwtVo_exp(validGoogleIss, validGoogleAud, 1676559600L);
-//        assertThrows(TokenExpiredException.class, () -> authService.verifyToken(jwtVo));
-//    }
-//
-//}
+package com.bootme.auth.service;
+
+import static com.bootme.util.fixture.AuthFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.bootme.auth.exception.InvalidAudienceException;
+import com.bootme.auth.exception.InvalidIssuedAtException;
+import com.bootme.auth.exception.InvalidIssuerException;
+import com.bootme.auth.exception.TokenExpiredException;
+import com.bootme.util.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+
+@DisplayName("AuthService 클래스의")
+class AuthServiceTest extends ServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @DisplayName("verifyIssuer()는 ID 토큰의 iss 값이 유효하지 않을 경우 예외를 발생시킨다.")
+    @Test
+    void verifyIssuer() {
+        String jwt = getJwt("https://invalid.issuer.com", VALID_NAVER_AUDIENCE);
+        assertThrows(InvalidIssuerException.class, () -> authService.verifyToken(jwt));
+    }
+
+    @DisplayName("verifyAudience()는 ID 토큰의 aud 값이 유효하지 않을 경우 예외를 발생시킨다.")
+    @Test
+    void verifyAudience(){
+        String jwt = getJwt(VALID_NAVER_ISSUER, "invalidAudience");
+        assertThrows(InvalidAudienceException.class, () -> authService.verifyToken(jwt));
+    }
+
+    @DisplayName("verifyIssuedAt()은 ID 토큰의 iat 값이 유효하지 않을 경우 예외를 발생시킨다.")
+    @Test
+    void verifyIssuedAt(){
+        Date now = new Date();
+        Date issuedAt = new Date(now.getTime() + 600000); // 토큰 발행시간이 미래
+
+        String jwt = getJwt(issuedAt, VALID_EXP);
+        assertThrows(InvalidIssuedAtException.class, () -> authService.verifyToken(jwt));
+    }
+
+    @DisplayName("verifyExpiration()은 ID 토큰의 exp 값이 유효하지 않을 경우 예외를 발생시킨다.")
+    @Test
+    void verifyExpiration(){
+        Date now = new Date();
+        Date expirationTime = new Date(now.getTime() - 600000); // 토큰 만료시간이 과거
+
+        String jwt = getJwt(VALID_IAT, expirationTime);
+        assertThrows(TokenExpiredException.class, () -> authService.verifyToken(jwt));
+    }
+
+}

--- a/backend/src/test/java/com/bootme/util/fixture/AuthFixture.java
+++ b/backend/src/test/java/com/bootme/util/fixture/AuthFixture.java
@@ -1,48 +1,42 @@
 package com.bootme.util.fixture;
 
-import com.bootme.auth.dto.JwtVo;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
 
 public class AuthFixture {
-    public static final JwtVo.Header VALID_JWT_HEADER = JwtVo.Header.builder()
-                                                            .alg("RS256")
-                                                            .kid("274052a2b6448745764e72c359091d90cfb585a")
-                                                            .typ("JWT")
-                                                            .build();
-    public static final Long VALID_IAT = 1675313707L;
-    public static final Long VALID_EXP = 2524608000L;
-    public static final String VALID_EMAIL = "valid@email.com";
+    public static final String VALID_NAVER_ISSUER = "https://bootme.front.com";
+    public static final String VALID_NAVER_AUDIENCE = "bootme.com";
+    public static final Date VALID_IAT = new Date(new Date().getTime());
+    public static final Date VALID_EXP = new Date(new Date().getTime() + 86400000);
+    private static final String SECRET_KEY = "secretKeyForTesting:KeysUsedWithHMAC-SHA-AlgorithmsMustHaveASize>=256bits";
+    private static final Key SIGNING_KEY = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
 
-    public static JwtVo getJwtVo(String issuer, String audience){
-        JwtVo.Body body = JwtVo.Body.builder()
-                .iss(issuer)
-                .aud(audience)
-                .iat(VALID_IAT)
-                .exp(VALID_EXP)
-                .email(VALID_EMAIL)
-                .build();
-        return new JwtVo(VALID_JWT_HEADER, body);
+    // 토큰의 issuer, audience 검증시 사용
+    public static String getJwt(String issuer, String audience) {
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setIssuer(issuer)
+                .setAudience(audience)
+                .setIssuedAt(VALID_IAT)
+                .setExpiration(VALID_EXP)
+                .signWith(SIGNING_KEY)
+                .compact();
     }
 
-    public static JwtVo getJwtVo(String issuer, String audience, Long issuedAt){
-        JwtVo.Body body = JwtVo.Body.builder()
-                .iss(issuer)
-                .aud(audience)
-                .iat(issuedAt)
-                .exp(VALID_EXP)
-                .email(VALID_EMAIL)
-                .build();
-        return new JwtVo(VALID_JWT_HEADER, body);
-    }
-
-    public static JwtVo getJwtVo_exp(String issuer, String audience, Long expirationTime){
-        JwtVo.Body body = JwtVo.Body.builder()
-                .iss(issuer)
-                .aud(audience)
-                .iat(VALID_IAT)
-                .exp(expirationTime)
-                .email(VALID_EMAIL)
-                .build();
-        return new JwtVo(VALID_JWT_HEADER, body);
+    // 토큰의 발행시간, 만료시간 검증시 사용
+    public static String getJwt(Date issuedAt, Date expirationTime) {
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setIssuer(VALID_NAVER_ISSUER)
+                .setAudience(VALID_NAVER_AUDIENCE)
+                .setIssuedAt(issuedAt)
+                .setExpiration(expirationTime)
+                .signWith(SIGNING_KEY)
+                .compact();
     }
 
 }


### PR DESCRIPTION
- **ID 토큰의 `Issuer`, `Audience`, `IssuedAt`, `Expiration` 검증하는 메서드의 단위 테스트 작성**
  - 토큰의 서명을 검증하는 메서드의 단위 테스트 작성하지 않음
    - 서명 검증 위해서는 구글, 카카오가 발행한 ID 토큰이 필요함
    - 그러나 실제 ID 토큰으로 테스트 구현하는데 어려움 많아 중단함

```java
    @DisplayName("verifyIssuer()는 ID 토큰의 iss 값이 유효하지 않을 경우 예외를 발생시킨다.")
    @Test
    void verifyIssuer() {
        String jwt = getJwt("https://invalid.issuer.com", VALID_NAVER_AUDIENCE);
        assertThrows(InvalidIssuerException.class, () -> authService.verifyToken(jwt));
    }

    @DisplayName("verifyAudience()는 ID 토큰의 aud 값이 유효하지 않을 경우 예외를 발생시킨다.")
    @Test
    void verifyAudience(){
        String jwt = getJwt(VALID_NAVER_ISSUER, "invalidAudience");
        assertThrows(InvalidAudienceException.class, () -> authService.verifyToken(jwt));
    }

    @DisplayName("verifyIssuedAt()은 ID 토큰의 iat 값이 유효하지 않을 경우 예외를 발생시킨다.")
    @Test
    void verifyIssuedAt(){
        Date now = new Date();
        Date issuedAt = new Date(now.getTime() + 600000); // 토큰 발행시간이 미래

        String jwt = getJwt(issuedAt, VALID_EXP);
        assertThrows(InvalidIssuedAtException.class, () -> authService.verifyToken(jwt));
    }

    @DisplayName("verifyExpiration()은 ID 토큰의 exp 값이 유효하지 않을 경우 예외를 발생시킨다.")
    @Test
    void verifyExpiration(){
        Date now = new Date();
        Date expirationTime = new Date(now.getTime() - 600000); // 토큰 만료시간이 과거

        String jwt = getJwt(VALID_IAT, expirationTime);
        assertThrows(TokenExpiredException.class, () -> authService.verifyToken(jwt));
    }
```



***

close #157 







