### PR TITLE
[FE] 코스 정렬 기능 구현

### DIFF
--- a/frontend/src/hooks/usePaging.tsx
+++ b/frontend/src/hooks/usePaging.tsx
@@ -41,7 +41,7 @@ const usePaging = (maxPage: number) => {
     return items!.slice(indexOfFirstCard, indexOfLastCard);
   };
 
-  return { currentPage, handleNumberClick, handleNextClick, handlePrevClick, getCurrentItems };
+  return { currentPage, setCurrentPage, handleNumberClick, handleNextClick, handlePrevClick, getCurrentItems };
 };
 
 export default usePaging;

--- a/frontend/src/hooks/useSorting.tsx
+++ b/frontend/src/hooks/useSorting.tsx
@@ -1,0 +1,39 @@
+import { useState, useMemo } from 'react';
+
+const useSorting = (courseCards: Course[]): useSortingProps => {
+  const [sortOption, setSortOption] = useState('popular');
+
+  // todo: Course API 에 북마크 저장 횟수, 등록일자 가져오도록 변경한 후 정렬 수정 필요
+  const sortedCards = useMemo(() => {
+    switch (sortOption) {
+      case 'popular':
+        return [...courseCards].sort((a, b) => b.cost - a.cost);
+      case 'newest':
+        return [...courseCards].sort((a, b) => a.id - b.id);
+      // return courseCards.sort((a, b) => new Date(b.dates.courseStartDate) - new Date(a.dates.courseStartDate));
+      case 'bookmark':
+        return [...courseCards].sort((a, b) => b.period - a.period);
+      // return courseCards.sort((a, b) => b.bookmarked - a.bookmarked);
+      default:
+        return courseCards;
+    }
+  }, [courseCards, sortOption]);
+
+  const handleSorting = (option: string) => {
+    setSortOption(option);
+  };
+
+  return {
+    sortedCards,
+    sortOption,
+    handleSorting,
+  };
+};
+
+export default useSorting;
+
+interface useSortingProps {
+  sortedCards: Course[];
+  sortOption: string;
+  handleSorting: (option: string) => void;
+}

--- a/frontend/src/hooks/useSorting.tsx
+++ b/frontend/src/hooks/useSorting.tsx
@@ -4,16 +4,44 @@ const useSorting = (courseCards: Course[]): useSortingProps => {
   const [sortOption, setSortOption] = useState('popular');
 
   // todo: Course API 에 북마크 저장 횟수, 등록일자 가져오도록 변경한 후 정렬 수정 필요
+  /**
+   * 정렬 옵션별 우선순위
+   *  인기순: 인기순 > 등록순 > 북마크순   ex) 인기순 정렬 선택시 클릭수가 같다면 최근 등록순으로 정렬
+   *  등록순: 등록순 > 인기순 > 북마크순
+   *  북마크순: 북마크순 > 인기순 > 등록순
+   */
   const sortedCards = useMemo(() => {
     switch (sortOption) {
       case 'popular':
-        return [...courseCards].sort((a, b) => b.cost - a.cost);
+        return [...courseCards].sort((a, b) => {
+          if (b.cost === a.cost) {
+            if (b.id === a.id) {
+              return b.period - a.period;
+            }
+            return b.id - a.id;
+          }
+          return b.cost - a.cost;
+        });
       case 'newest':
-        return [...courseCards].sort((a, b) => a.id - b.id);
-      // return courseCards.sort((a, b) => new Date(b.dates.courseStartDate) - new Date(a.dates.courseStartDate));
+        return [...courseCards].sort((a, b) => {
+          if (a.id === b.id) {
+            if (b.cost === a.cost) {
+              return b.period - a.period;
+            }
+            return b.cost - a.cost;
+          }
+          return a.id - b.id;
+        });
       case 'bookmark':
-        return [...courseCards].sort((a, b) => b.period - a.period);
-      // return courseCards.sort((a, b) => b.bookmarked - a.bookmarked);
+        return [...courseCards].sort((a, b) => {
+          if (b.period === a.period) {
+            if (b.cost === a.cost) {
+              return b.id - a.id;
+            }
+            return b.cost - a.cost;
+          }
+          return b.period - a.period;
+        });
       default:
         return courseCards;
     }

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,7 +1,7 @@
 import {
   CourseCount,
   FilterButton,
-  FilterSelect,
+  SortSelect,
   PaginationWrapper,
   FooterWrapper,
   Footer,
@@ -27,6 +27,7 @@ import Header from '../../components/Header';
 import SideFilter from '../../components/Filters/SideFilter';
 import { useFilters } from '../../hooks/useFilters';
 import ModalFilter from '../../components/Filters/ModalFilter';
+import { Select } from 'antd';
 
 const Home = () => {
   // Fetching data
@@ -86,11 +87,17 @@ const Home = () => {
                       <FilterButton primary onClick={handleModal}>
                         <span> 검색 필터 </span>
                       </FilterButton>
-                      <FilterSelect>
-                        <option value={'recent'}> 최신순</option>
-                        <option value={'popular'}> 인기순</option>
-                        <option value={'popular'}> 응답률순</option>
-                      </FilterSelect>
+                      <SortSelect>
+                        <Select
+                          defaultValue="인기순"
+                          style={{ width: 94 }}
+                          options={[
+                            { value: 'popular', label: '인기순' },
+                            { value: 'newest', label: '등록순' },
+                            { value: 'bookmark', label: '북마크순' },
+                          ]}
+                        />
+                      </SortSelect>
                     </MenuRight>
                   </CourseListMenu>
                   <CourseCardList cards={currentCards} />

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -28,6 +28,7 @@ import SideFilter from '../../components/Filters/SideFilter';
 import { useFilters } from '../../hooks/useFilters';
 import ModalFilter from '../../components/Filters/ModalFilter';
 import { Select } from 'antd';
+import useSorting from '../../hooks/useSorting';
 
 const Home = () => {
   // Fetching data
@@ -41,11 +42,14 @@ const Home = () => {
     filteredCourses = filterCourses(data);
   }
 
+  // Sorting
+  const { sortedCards, handleSorting } = useSorting(filteredCourses);
+
   // Pagination
   const [cardsPerPage] = useState(12);
   const maxPage = Math.floor(length / cardsPerPage) + 1;
   const { currentPage, handleNumberClick, handleNextClick, handlePrevClick, getCurrentItems } = usePaging(maxPage);
-  const currentCards = getCurrentItems(cardsPerPage, filteredCourses);
+  const currentCards = getCurrentItems(cardsPerPage, sortedCards);
 
   useEffect(() => {
     handleLength(filteredCourses.length);
@@ -96,11 +100,12 @@ const Home = () => {
                             { value: 'newest', label: '등록순' },
                             { value: 'bookmark', label: '북마크순' },
                           ]}
+                          onSelect={handleSorting}
                         />
                       </SortSelect>
                     </MenuRight>
                   </CourseListMenu>
-                  <CourseCardList cards={currentCards} />
+                  <CourseCardList currentCards={currentCards} />
                 </>
               )}
             </CourseListWrapper>

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -43,17 +43,27 @@ const Home = () => {
   }
 
   // Sorting
-  const { sortedCards, handleSorting } = useSorting(filteredCourses);
+  const { sortOption, sortedCards, handleSorting } = useSorting(filteredCourses);
 
   // Pagination
   const [cardsPerPage] = useState(12);
   const maxPage = Math.floor(length / cardsPerPage) + 1;
-  const { currentPage, handleNumberClick, handleNextClick, handlePrevClick, getCurrentItems } = usePaging(maxPage);
+  const { currentPage, setCurrentPage, handleNumberClick, handleNextClick, handlePrevClick, getCurrentItems } =
+    usePaging(maxPage);
   const currentCards = getCurrentItems(cardsPerPage, sortedCards);
 
   useEffect(() => {
     handleLength(filteredCourses.length);
   }, [filteredCourses]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+    console.log('하');
+  }, [sortOption]);
 
   if (isLoading) {
     return <p>to do: 로딩중 화면 작성</p>;

--- a/frontend/src/pages/Home/style.ts
+++ b/frontend/src/pages/Home/style.ts
@@ -110,32 +110,26 @@ export const CourseListMenu = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 0;
   vertical-align: middle;
 
   @media (max-width: 575px) {
     align-items: center;
-    padding: 0.5rem 0;
-  }
-
-  @media (min-width: 767px) {
-    display: none;
   }
 `;
 
-export const MenuLeft = styled.div``;
+export const MenuLeft = styled.div`
+  height: 32px;
+  display: flex;
+  align-items: flex-end;
+`;
 
-export const CourseCount = styled.h6`
-  display: block;
+export const CourseCount = styled.span`
   margin-left: 1rem;
-  margin-bottom: 0.25rem;
-  font-size: 1rem;
   font-weight: 700;
-  vertical-align: top;
   line-height: 1.5;
-  margin-top: 0;
+  font-size: 14px;
 
-  @media (max-width: 767px) {
+  @media (max-width: 575px) {
     font-size: 13px;
   }
 `;
@@ -146,45 +140,22 @@ export const FilterButton = styled(Button)`
   display: inline-flex;
   align-items: center;
   max-height: 1.9375rem;
-  font-size: 15px;
+  font-size: 14px;
 
   span {
     display: inline-block;
     vertical-align: middle;
   }
 
-  @media (max-width: 767px) {
-    font-size: 14px;
+  @media (min-width: 768px) {
+    display: none;
   }
 `;
 
-export const FilterSelect = styled.select`
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  background-image: url(https://career.programmers.co.kr/assets/toggle-black-3ebb19a240c1ef57dac0b24e19fd00eff32a7e32ff8f2b87cfa2eb399c193c3a.png);
-  background-position: calc(100% - 0.5rem) 49%;
-  background-repeat: no-repeat;
-  background-size: 0.625rem 0.3125rem;
-  border: 1px solid #d7e2eb;
-  border-radius: 0.25rem;
-  color: #263747;
-  padding: 0.3125rem 1.5rem 0.3125rem 0.8125rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  line-height: 1.25rem;
-  background-color: transparent;
-  display: inline-block;
-  text-align: center;
-  vertical-align: middle;
-  user-select: none;
-  word-wrap: normal;
-  text-transform: none;
+export const SortSelect = styled.div`
+  display: inline-flex;
   margin-left: 4.5px;
-
-  @media (max-width: 767px) {
-    font-size: 0.8125rem;
-    line-height: 1.125rem;
-  }
+  vertical-align: middle;
 `;
 
 export const PaginationWrapper = styled.div`


### PR DESCRIPTION
## 정렬 옵션
 No. | 옵션명 | 기준 데이터 | 상세 기준 | DB Column (Course)
-- | -- | -- | -- | --
1 | 인기순 (default) | 클릭 횟수 | 최근 일주일간 클릭 횟수 내림차순 | clicks (구현 필요)
2 | 등록순 | 등록 일자 | 등록일자 내림차순 | createdAt
3 | 북마크순 | 북마크 저장 | 북마크 저장 횟수 내림차순 | bookmark (구현 필요)
- 코스 정렬에 다음 값들 필요하지만 아직 코스 조회 API에 구현되지 않음. 추후 구현후 수정 필요
  - 클릭수
  - 등록 일자
  - 북마크 저장 수
- 우선 다음 값으로 정렬 되도록 설정해둠
  - 인기순 선택시: 코스 비용 값 내림차순
  - 등록순 선택시: 코스 id 값 오름차순
  - 북마크순 선택시: 수강기간 값 내림차순

## 기타 사항
- [andt 라이브러리](https://ant.design/components/select) 사용하여 정렬 버튼 UI 구현
- 정렬 옵션을 선택하면 1페이지로 이동하도록 구현
  - 현재 조회 중인 페이지가 2 페이지 이상인 상태에서 정렬 옵션을 변경했을 때, 
  옵션 변경 이후에도 해당 페이지에 남아 있는 것은 유저 예상과 다르기 때문에 1 페이지로 이동하도록 구현
- 선택한 정렬 옵션의 값이 같은 경우 정렬 우선순위 설정
  - 인기순: 인기순 > 등록순 > 북마크순
    - ex) 인기순 정렬 선택시 클릭수가 같은 코스는 최근 등록된순으로 정렬됨
  - 등록순: 등록순 > 인기순 > 북마크순
  - 북마크순: 북마크순 > 인기순 > 등록순
 
## 스크린샷
<img width="553" alt="image" src="https://user-images.githubusercontent.com/44575214/219869484-3d4edfb6-e85d-4e33-b9e2-3d824069070f.png">


***

close #159 
