### PR TITLE
[BE] Webhook 사용한 코스 클릭수, 북마크수 트래킹 구현

### DIFF
--- a/backend/src/main/java/com/bootme/auth/service/AuthService.java
+++ b/backend/src/main/java/com/bootme/auth/service/AuthService.java
@@ -283,4 +283,15 @@ public class AuthService {
             return "NickName=" + idInEmail + ", ProfileImage=" + jwtBody.getPicture();
     }
 
+    public void verifyWebhookJwt(String jwt, String webhookSecret){
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(webhookSecret.getBytes()))
+                    .build()
+                    .parseClaimsJws(jwt);
+        } catch (JwtException e) {
+            throw new InvalidSignatureException(INVALID_SIGNATURE, "verifyWebhookSecret()");
+        }
+    }
+
 }

--- a/backend/src/main/java/com/bootme/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/bootme/common/exception/ErrorType.java
@@ -17,9 +17,10 @@ public enum ErrorType {
     FORBIDDEN_REQUEST       (FORBIDDEN,    1004, "권한이 없습니다."),
     INVALID_ISSUER          (UNAUTHORIZED, 1005, "유효하지 않은 토큰 발급자입니다."),
     INVALID_AUDIENCE        (UNAUTHORIZED, 1006, "토큰의 Audience 값이 유효하지 않습니다."),
-    INVALID_ISSUED_AT       (UNAUTHORIZED, 1007, "토큰의 발행시간이 올바르지 않습니다. "),
-    TOKEN_EXPIRED           (UNAUTHORIZED, 1008, "토큰이 만료되었습니다. "),
-    INVALID_SIGNATURE       (UNAUTHORIZED, 1009, "토큰이 서명이 올바르지 않습니다. "),
+    INVALID_ISSUED_AT       (UNAUTHORIZED, 1007, "토큰의 발행시간이 올바르지 않습니다."),
+    TOKEN_EXPIRED           (UNAUTHORIZED, 1008, "토큰이 만료되었습니다."),
+    INVALID_SIGNATURE       (UNAUTHORIZED, 1009, "토큰이 서명이 올바르지 않습니다."),
+    INVALID_EVENT           (UNAUTHORIZED, 1010, "유효하지 않은 webhook 이벤트입니다."),
 
     NOT_FOUND_COURSE        (BAD_REQUEST,  3001, "존재하지 않는 코스입니다."),
 

--- a/backend/src/main/java/com/bootme/course/repository/CourseRepository.java
+++ b/backend/src/main/java/com/bootme/course/repository/CourseRepository.java
@@ -2,8 +2,23 @@ package com.bootme.course.repository;
 
 import com.bootme.course.domain.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface CourseRepository extends JpaRepository<Course, Long> {
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Course c SET c.clicks = c.clicks + 1 WHERE c.id = :id")
+    void incrementClicks(@Param("id") Long id);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Course c SET c.bookmarks = c.bookmarks + 1 WHERE c.id = :id")
+    void incrementBookmarks(@Param("id") Long id);
+
 }

--- a/backend/src/main/java/com/bootme/course/service/CourseService.java
+++ b/backend/src/main/java/com/bootme/course/service/CourseService.java
@@ -66,4 +66,16 @@ public class CourseService {
         courseRepository.delete(course);
     }
 
+    public void incrementClicks(Long id){
+        courseRepository.findById(id)
+                .orElseThrow(() -> new CourseNotFoundException(NOT_FOUND_COURSE));
+        courseRepository.incrementClicks(id);
+    }
+
+    public void incrementBookmarks(Long id){
+        courseRepository.findById(id)
+                .orElseThrow(() -> new CourseNotFoundException(NOT_FOUND_COURSE));
+        courseRepository.incrementBookmarks(id);
+    }
+
 }

--- a/backend/src/main/java/com/bootme/webhook/controller/WebhookController.java
+++ b/backend/src/main/java/com/bootme/webhook/controller/WebhookController.java
@@ -1,0 +1,62 @@
+package com.bootme.webhook.controller;
+
+import com.bootme.auth.service.AuthService;
+import com.bootme.course.service.CourseService;
+import com.bootme.webhook.dto.WebhookRequest;
+import com.bootme.webhook.exception.InvalidEventException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+import static com.bootme.common.exception.ErrorType.INVALID_EVENT;
+
+@CrossOrigin
+@RestController
+@RequestMapping("/webhook")
+public class WebhookController {
+
+    private final AuthService authService;
+    private final CourseService courseService;
+
+    private final String WEBHOOK_SECRET;
+
+    public WebhookController(AuthService authService,
+                             CourseService courseService,
+                             @Value("${security.jwt.bootme.webhook-secret}") String WEBHOOK_SECRET) {
+        this.authService = authService;
+        this.courseService = courseService;
+        this.WEBHOOK_SECRET = WEBHOOK_SECRET;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> handleWebhook(@RequestHeader(name = "Bootme_Secret") String secret,
+                                           @RequestBody WebhookRequest webhookRequest) {
+        final String COURSE_CLICKED = "courseClicked";
+        final String COURSE_BOOKMARKED = "courseBookmarked";
+        final String EVENT = webhookRequest.getEvent();
+        final Map<String, String> DATA = webhookRequest.getData();
+        final Long COURSE_ID = Long.parseLong(DATA.get("courseId"));
+
+        authService.verifyWebhookJwt(secret, WEBHOOK_SECRET);
+
+        try {
+            switch (EVENT) {
+                case COURSE_CLICKED:
+                    courseService.incrementClicks(COURSE_ID);
+                    break;
+                case COURSE_BOOKMARKED:
+                    courseService.incrementBookmarks(COURSE_ID);
+                    break;
+                default:
+                    throw new InvalidEventException(INVALID_EVENT, webhookRequest.getEvent());
+            }
+        } catch (InvalidEventException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+}

--- a/backend/src/main/java/com/bootme/webhook/dto/WebhookRequest.java
+++ b/backend/src/main/java/com/bootme/webhook/dto/WebhookRequest.java
@@ -1,0 +1,18 @@
+package com.bootme.webhook.dto;
+
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Getter
+public class WebhookRequest {
+
+    private long sessionId;
+    private long memberId;
+    private String event;
+    private final Map<String, String> data = new ConcurrentHashMap<>();
+    private String url;
+    private long createdAt;
+
+}

--- a/backend/src/main/java/com/bootme/webhook/exception/InvalidEventException.java
+++ b/backend/src/main/java/com/bootme/webhook/exception/InvalidEventException.java
@@ -1,0 +1,12 @@
+package com.bootme.webhook.exception;
+
+import com.bootme.common.exception.ErrorType;
+import com.bootme.common.exception.UnauthorizedException;
+
+public class InvalidEventException extends UnauthorizedException {
+
+    public InvalidEventException(final ErrorType errorType, final String event) {
+        super(errorType, event);
+    }
+
+}


### PR DESCRIPTION
<h2>Webhook 구현 이유: 트래킹 요청의 Reactive한 성격</h2>

### Webhook, 일반 REST API 비교
Characteristic | Webhook | Traditional REST API
-- | -- | --
Design approach: | Reactive ✓ | Proactive
Server response data: | No ✓| Yes
Triggered by specific events? | Yes ✓ | No (yes..?)
Requests initiated by: | Outer applications or services | Client applications
Communication direction: | Incoming and outgoing<br> (little outgoing data) ✓ | Incoming and outgoing |  
Real-time communication: | Yes | Not necessarily
Data sent in request body: | Specific event data ✓ | General request data

<ul>
<li>
<p>트래킹 기능을 Webhook으로 구현한 가장 결정적인 요인은 트래킹 관련 요청들이 <code>Reactive</code> 한 성격이기 때문</p>
</li>
<li>
<p>로그인 요청과 같은 일반적인 경우에 HTTP Request의 목적은 유저 행동의 목적과 일치함 (<code>Proactive</code>) <br>
그러나 트래킹 관련 HTTP Request의 목적은 유저 행동의 목적과 불일치함 (<code>Reactive</code>)</p>


  | 로그인 request | 코스 클릭수 트래킹 request
-- | -- | --
유저의 행동 | 로그인 버튼 클릭 | 특정 코스 클릭
유저의 의도 | 로그인 목적 | 코스 상세 정보 조회 목적
HTTP 요청의 의도 | 유저를 로그인 시킬 목적 | 코스 클릭수 트래킹 목적


<ul>
<li>오히려 유저는 트래킹 관련 HTTP Request가 서버로 전송된다는 것에 대해 예상조차 못함</li>
<li>이처럼 HTTP Request 성격의 차이가 있기 때문에 서버에서도 이러한 요청을 다르게 처리해야할 필요성을 느낌</li>
<li><code>Reactive</code> 한 성격의 요청을 처리하기 좋은 것이 webhook 형태라고 판단하여 트래킹 요청은 webhook endpoint에서 처리하는 것으로 구현함</li>
</ul>
</li>
</ul>

<br>


## Webhook Endpoint 구현
```java
    @PostMapping
    public ResponseEntity<?> handleWebhook(@RequestHeader(name = "Bootme_Secret") String secret,
                                           @RequestBody WebhookRequest webhookRequest) {
        final String COURSE_CLICKED = "courseClicked";
        final String COURSE_BOOKMARKED = "courseBookmarked";
        final String EVENT = webhookRequest.getEvent();
        final Map<String, String> DATA = webhookRequest.getData();
        final Long COURSE_ID = Long.parseLong(DATA.get("courseId"));

        authService.verifyWebhookJwt(secret, WEBHOOK_SECRET);

        try {
            switch (EVENT) {
                case COURSE_CLICKED:
                    courseService.incrementClicks(COURSE_ID);
                    break;
                case COURSE_BOOKMARKED:
                    courseService.incrementBookmarks(COURSE_ID);
                    break;
                default:
                    throw new InvalidEventException(INVALID_EVENT, webhookRequest.getEvent());
            }
        } catch (InvalidEventException e) {
            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
        }
        return new ResponseEntity<>(HttpStatus.OK);
    }
```

- 헤더로 전달된 토큰 검증 후 이벤트에 맞는 처리 진행
- 트래킹과 관련된 요청은 webhook 처리


## Webhook Object

```jsx
Header:
  BOOTME_SECRET: "임의 생성한 시크릿 값 (.env, application.yml 관리)"

Body:
{
	"sessionId": 123,	
	"memberId": 456,
	"createdAt": 131231231,
	"event": "courseClicked",
	"data": {
			"courseId" : "1"
		},
	"url": "이벤트가 발생한 url"
}
```

- 참고
  - [https://stripe.com/docs/api/webhook_endpoints/object](https://stripe.com/docs/api/webhook_endpoints/object)
  - [https://stripe.com/docs/webhooks#webhook-endpoint-one](https://stripe.com/docs/webhooks#webhook-endpoint-one)

<br>

## Webhook Events
| 이벤트명 | 발생 기준 | 서버 처리 |
| --- | --- | --- |
| COURSE_CLICKED | ‘코스 타이틀’ 클릭됨 <br> ’회사 로고’ 클릭됨 <br> ’회사명’ 클릭됨 <br> ’북마크 저장’ 클릭됨 | 해당 코스 아이템의 clicks 필드 1 증가 |
| COURSE_BOOKMARKED | ’북마크 저장’ 클릭됨 | 해당 코스 아이템의 bookmarks 필드 1 증가 |





<br>





***

close #163 







