### PR TITLE
[FE] 코스 북마크 저장 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@ant-design/icons": "^5.0.1",
         "antd": "^5.2.0",
         "axios": "^1.2.1",
         "dotenv": "^16.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/Jinwook94/bootme",
   "dependencies": {
+    "@ant-design/icons": "^5.0.1",
     "antd": "^5.2.0",
     "axios": "^1.2.1",
     "dotenv": "^16.0.3",

--- a/frontend/src/components/CourseCard/index.tsx
+++ b/frontend/src/components/CourseCard/index.tsx
@@ -18,6 +18,8 @@ import { HeartFilled, HeartOutlined } from '@ant-design/icons';
 import DateFormatter from './dateFormatter';
 import useWebhook from '../../hooks/useWebhook';
 import { COURSE_BOOKMARKED, COURSE_CLICKED } from '../../constants/webhook';
+import { useEffect } from 'react';
+import useBookmarks from '../../hooks/useBookmarks';
 
 const CourseCard = ({
   id,
@@ -30,10 +32,16 @@ const CourseCard = ({
   period,
   cost,
   costType,
-}: CourseCardProps) => {
+  bookmarked,
+}: CourseCardProps & { bookmarked: boolean }) => {
   const weeks = Math.round(period / 7);
   const months = Math.round(period / 30);
   const { sendWebhookNoti } = useWebhook();
+  const { isBookmarked, setIsBookmarked, handleBookmark } = useBookmarks();
+
+  useEffect(() => {
+    setIsBookmarked(bookmarked);
+  }, []);
 
   return (
     <Wrapper>
@@ -107,6 +115,7 @@ const CourseCard = ({
       </ItemBody>
       <Bookmark
         onClick={() => {
+          handleBookmark(id);
           sendWebhookNoti(COURSE_CLICKED, id);
           sendWebhookNoti(COURSE_BOOKMARKED, id);
         }}

--- a/frontend/src/components/CourseCard/index.tsx
+++ b/frontend/src/components/CourseCard/index.tsx
@@ -14,7 +14,7 @@ import {
 } from './style';
 
 import './style.css';
-import BookmarkIcon from '../../assets/bookmark.svg';
+import { HeartFilled, HeartOutlined } from '@ant-design/icons';
 import DateFormatter from './dateFormatter';
 import useWebhook from '../../hooks/useWebhook';
 import { COURSE_BOOKMARKED, COURSE_CLICKED } from '../../constants/webhook';
@@ -111,7 +111,7 @@ const CourseCard = ({
           sendWebhookNoti(COURSE_BOOKMARKED, id);
         }}
       >
-        <BookmarkIcon />
+        {isBookmarked ? <HeartFilled /> : <HeartOutlined />}
       </Bookmark>
     </Wrapper>
   );

--- a/frontend/src/components/CourseCardList/index.tsx
+++ b/frontend/src/components/CourseCardList/index.tsx
@@ -1,25 +1,33 @@
 import CourseCard, { CourseCardProps } from '../CourseCard';
 import { CourseCardListStyle } from './style';
 import React from 'react';
+import useBookmarks from '../../hooks/useBookmarks';
 
 const CourseCardList = ({ currentCards }: CourseCardListProps) => {
+  const { bookmarkedCourses, isLoading } = useBookmarks();
+
   return (
     <CourseCardListStyle>
-      {currentCards.map(
-        ({ id, title, url, company, categories, stacks, dates, period, cost, costType }: CourseCardProps) => (
-          <CourseCard
-            key={id}
-            title={title}
-            url={url}
-            company={company}
-            categories={categories}
-            stacks={stacks}
-            dates={dates}
-            cost={cost}
-            costType={costType}
-            period={period}
-            id={id}
-          />
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : (
+        currentCards.map(
+          ({ id, title, url, company, categories, stacks, dates, period, cost, costType }: CourseCardProps) => (
+            <CourseCard
+              key={id}
+              id={id}
+              title={title}
+              url={url}
+              company={company}
+              categories={categories}
+              stacks={stacks}
+              dates={dates}
+              cost={cost}
+              costType={costType}
+              period={period}
+              bookmarked={bookmarkedCourses.includes(id)}
+            />
+          )
         )
       )}
     </CourseCardListStyle>

--- a/frontend/src/hooks/useBookmarks.tsx
+++ b/frontend/src/hooks/useBookmarks.tsx
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetcher } from '../api/fetcher';
+
+const useBookmarks = () => {
+  const [isBookmarked, setIsBookmarked] = useState<boolean>(false);
+  const memberId = localStorage.getItem('MemberId');
+  const [bookmarkedCourses, setBookmarkedCourses] = useState<number[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const getBookmarkedCourses = () => {
+    const endpoint = `/member/${memberId}/bookmarks`;
+    fetcher
+      .get(endpoint, {})
+      .then(response => {
+        setBookmarkedCourses(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    getBookmarkedCourses();
+  }, []);
+
+  const handleBookmark = useCallback(
+    async (id: number) => {
+      const endpoint = `/member/${memberId}/bookmarks/${id}`;
+      const method = isBookmarked ? 'DELETE' : 'POST';
+
+      try {
+        await fetcher(endpoint, {
+          method: method,
+        });
+        setIsBookmarked(!isBookmarked);
+        getBookmarkedCourses(); // call the function to update bookmarked courses
+      } catch (error) {
+        console.error(`Failed to ${method} bookmark for course ${id}:`, error);
+      }
+    },
+    [isBookmarked, memberId]
+  );
+
+  return {
+    isBookmarked,
+    setBookmarkedCourses,
+    isLoading,
+    getBookmarkedCourses,
+    setIsBookmarked,
+    bookmarkedCourses,
+    handleBookmark,
+  };
+};
+
+export default useBookmarks;

--- a/frontend/src/hooks/useLogin.tsx
+++ b/frontend/src/hooks/useLogin.tsx
@@ -53,6 +53,7 @@ export const LoginProvider = ({ children }: LoginProviderProps) => {
       .post('/logout', null, {})
       .then(() => {
         setIsLogin(false);
+        localStorage.removeItem('MemberId');
         localStorage.removeItem('NickName');
         localStorage.removeItem('ProfileImage');
         location.reload();


### PR DESCRIPTION
## 코스 북마크 저장 프론트 구현
<img width="540" alt="image" src="https://user-images.githubusercontent.com/44575214/220254973-b2f571cb-488f-4ede-858b-e2e812911f81.png">


Case | User Event | isBookmarked | Action | Frontend
-- | -- | -- | -- | --
1 | 코스 카드의 북마크 버튼 클릭 | false | 북마크 추가 | 1. 북마크 추가 endpoint로 멤버 id, 코스 id 전송 <br> 2.북마크 버튼 `Filled`로 변경
2 | 코스 카드의 북마크 버튼 클릭 | true | 북마크 삭제 | 1. 북마크 삭제 endpoint로 멤버 id, 코스 id 전송 <br> 2. 북마크 버튼 `Outlined`로 변경

***

close #171 







