### PR TITLE
[FE] 로그인 처리 과정에서 유저 정보 사용할수 있도록 구현

### DIFF
--- a/frontend/src/components/LoginModal/GoogleLogin/index.tsx
+++ b/frontend/src/components/LoginModal/GoogleLogin/index.tsx
@@ -7,8 +7,8 @@ export const GoogleLoginButton = () => {
   return (
     <GoogleLogin
       onSuccess={credentialResponse => {
-        sendIdTokenToServer(credentialResponse.credential).then(() => {
-          handleLoginSuccess('google');
+        sendIdTokenToServer(credentialResponse.credential).then(initialUserInfo => {
+          handleLoginSuccess('google', initialUserInfo);
         });
       }}
       onError={() => {
@@ -27,8 +27,8 @@ export const GoogleLoginOneTap = () => {
 
   useGoogleOneTapLogin({
     onSuccess: credentialResponse => {
-      sendIdTokenToServer(credentialResponse.credential).then(() => {
-        handleLoginSuccess('google');
+      sendIdTokenToServer(credentialResponse.credential).then(initialUserInfo => {
+        handleLoginSuccess('google', initialUserInfo);
       });
     },
     onError: () => {

--- a/frontend/src/components/LoginModal/KakaoLogin/index.tsx
+++ b/frontend/src/components/LoginModal/KakaoLogin/index.tsx
@@ -56,8 +56,8 @@ export const KakaoLoginRedirect = () => {
    * */
   useEffect(() => {
     sendAccessTokenToKakao().then(idToken =>
-      sendIdTokenToServer(idToken).then(() => {
-        handleLoginSuccess('kakao');
+      sendIdTokenToServer(idToken).then(initialUserInfo => {
+        handleLoginSuccess('kakao', initialUserInfo);
       })
     );
   }, []);

--- a/frontend/src/components/LoginModal/NaverLogin/index.tsx
+++ b/frontend/src/components/LoginModal/NaverLogin/index.tsx
@@ -31,8 +31,8 @@ export const NaverLoginButton = () => {
     naverLogin.getLoginStatus(function (status: never) {
       if (status) {
         generateIdToken(naverLogin).then(idToken => {
-          sendIdTokenToServer(idToken).then(() => {
-            handleLoginSuccess('naver');
+          sendIdTokenToServer(idToken).then(initialUserInfo => {
+            handleLoginSuccess('naver', initialUserInfo);
           });
         });
       }

--- a/frontend/src/hooks/useLogin.tsx
+++ b/frontend/src/hooks/useLogin.tsx
@@ -8,7 +8,7 @@ const LoginContext = createContext<LoginContextProps>({
   setIsLogin: () => {},
   isLoginModal: false,
   handleLoginModal: () => {},
-  sendIdTokenToServer: () => Promise.resolve(),
+  sendIdTokenToServer: () => Promise.resolve({}),
   handleLogOut: () => {},
   handleLoginSuccess: () => {},
 });
@@ -44,14 +44,18 @@ export const LoginProvider = ({ children }: LoginProviderProps) => {
         },
       })
       .then(r => {
+        const initialUserInfo: Record<string, string> = {};
         const data = r.data.split(', ');
         data.forEach((item: string) => {
           const [key, value] = item.split('=');
           localStorage.setItem(key, value);
+          initialUserInfo[key] = value;
         });
+        return initialUserInfo;
       })
       .catch(error => {
         console.log(error);
+        return Promise.reject(error);
       });
   };
 
@@ -107,9 +111,9 @@ interface LoginContextProps {
   setIsLogin: React.Dispatch<boolean>;
   isLoginModal: boolean;
   handleLoginModal: () => void;
-  sendIdTokenToServer: (idToken: string | undefined) => Promise<void>;
+  sendIdTokenToServer: (idToken: string | undefined) => Promise<Record<string, string>>;
   handleLogOut: () => void;
-  handleLoginSuccess: (oAuthProvider: string) => void;
+  handleLoginSuccess: (oAuthProvider: string, initialUserInfo: Record<string, string>) => void;
 }
 
 interface LoginProviderProps {


### PR DESCRIPTION
## 문제상황
- 서버에서 로그인 응답 바디에 반환한 유저 정보를 프론트엔드 로그인 처리 과정중에서는 사용할 수 없음
- 유저 정보는 OAuth 로그인 완료 후 로컬 스토리지에 저장되는데, 로컬 스토리 저장 이후 바로 값을 꺼내면 빈 값이 반환됨
- 프론트엔드 로그인 처리 과정 중에도 로그인 응답에 포함된 유저 정보를 사용할 수 있도록 변경 필요
  - 로그인 처리 과정 중에 유저 정보 사용하여 유저의 알림 정보를 fetch 해야 하기 때문에


## AS-IS
```typescript
const sendIdTokenToServer = (idToken: string | undefined) => {
    return fetcher
      .post('/login', null, {
        headers: {
          Authorization: 'Bearer ' + idToken,
        },
      })
      .then(r => {
        const data = r.data.split(', ');
        data.forEach((item: string) => {
          const [key, value] = item.split('=');
          localStorage.setItem(key, value);
        });
      })
      .catch(error => {
        console.log(error);
      });
  };
```
- **OAuth 로그인 완료 후 유저 정보를 로컬 스토리지에만 저장함**
  - 서버에서 로그인 응답 바디에 MemberId, NickName, ProfileImage 3가지 유저 정보를 반환함
  - 각각을 로컬 스토리지에 저장함 `localStorage.setItem(key, value);`
- **로그인 완료 이후 유저 정보 필요시 로컬 스토리지에서 가져와서 사용함**
  - ex) `const [nickName, setNickName] = useState(localStorage.getItem('NickName'));`


## TO-BE
```typescript
  const sendIdTokenToServer = (idToken: string | undefined) => {
    return fetcher
      .post('/login', null, {
        headers: {
          Authorization: 'Bearer ' + idToken,
        },
      })
      .then(r => {
        const initialUserInfo: Record<string, string> = {};    // added
        const data = r.data.split(', ');
        data.forEach((item: string) => {
          const [key, value] = item.split('=');
          localStorage.setItem(key, value);
          initialUserInfo[key] = value;    // added
        });
        return initialUserInfo;    // added
      })
      .catch(error => {
        console.log(error);
        return Promise.reject(error);
      });
  };
```
- 로그인 완료 후 유저 정보를 로컬 스토리지에 저장할 뿐만 아니라 `initialUserInfo` 객체에 저장하여 반환
  - `initialUserInfo` 객체는 useState() 사용하여 관리하는 상태가 아니기 때문에 로그인 시점에도 바로 사용 가능
  - `handleLoginSuccess()`에서 유저의 알림 정보를 가져올 때 `initialUserInfo`의 `MemberId`를 사용
***

close #178 