### PR TITLE
[FE] 로그인 완료 후 서버에서 해당 유저의 알림 정보 받아와서 로컬 스토리지에 저장

### DIFF
--- a/frontend/src/hooks/useLogin.tsx
+++ b/frontend/src/hooks/useLogin.tsx
@@ -20,11 +20,27 @@ export const LoginProvider = ({ children }: LoginProviderProps) => {
   });
   const navigate = useNavigate();
 
-  const handleLoginSuccess = async (oAuthProvider: string) => {
+  const fetchNotifications = (initialUserInfo: Record<string, string>) => {
+    const memberId = initialUserInfo.MemberId;
+    const endpoint = `/notifications/${memberId}`;
+    return fetcher
+      .get(endpoint, {})
+      .then(r => {
+        localStorage.setItem('Notifications', JSON.stringify(r.data));
+      })
+      .catch(error => {
+        console.log(error);
+        return [];
+      });
+  };
+
+  const handleLoginSuccess = async (oAuthProvider: string, initialUserInfo: Record<string, string>) => {
     await setIsLogin(true);
     if (oAuthProvider == 'google') {
-      navigate(PATH.HOME);
-      setIsLoginModal(false);
+      fetchNotifications(initialUserInfo).then(() => {
+        navigate(PATH.HOME);
+        window.location.reload();
+      });
     }
     if (oAuthProvider == 'kakao') navigate(PATH.HOME);
     if (oAuthProvider == 'naver') navigate(PATH.HOME);


### PR DESCRIPTION
## 배경
- 로그인 완료 후 헤더의 알림 버튼에 유저의 알림 정보를 표시해야 함
  - 로그인 완료 후 서버에 해당 유저의 알림 정보 요청
  - 반환된 유저 알림 정보를 로컬 스토리지에 저장

- 추후 로컬 스토리지에 알림 개수가 1개 이상이면 알림 버튼 unchecked 활성화 될 수 있도록 구현

<br>

## TO-BE
```typescript
const handleLoginSuccess = async (oAuthProvider: string, initialUserInfo: Record<string, string>) => {
    await setIsLogin(true);
    if (oAuthProvider == 'google') {
      fetchNotifications(initialUserInfo).then(() => {    // added
        navigate(PATH.HOME);
        window.location.reload();
      });
    }
    if (oAuthProvider == 'kakao') navigate(PATH.HOME);
    if (oAuthProvider == 'naver') navigate(PATH.HOME);
  };


  // added
  const fetchNotifications = (initialUserInfo: Record<string, string>) => {
    const memberId = initialUserInfo.MemberId;
    const endpoint = `/notifications/${memberId}`;
    return fetcher
      .get(endpoint, {})
      .then(r => {
        localStorage.setItem('Notifications', JSON.stringify(r.data));
      })
      .catch(error => {
        console.log(error);
        return [];
      });
  };
```

<br>


***

close #180 
