### PR TITLE
[BE] 알림 기능 구현

### DIFF
--- a/backend/src/main/java/com/bootme/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/bootme/admin/controller/AdminController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
-@CrossOrigin
+
 @RestController
 @RequestMapping("/admin")
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/bootme/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bootme/auth/controller/AuthController.java
@@ -24,9 +24,9 @@ public class AuthController {
         JwtVo.Body jwtBody = jwtVo.getBody();
 
         authService.verifyToken(idToken);
-        authService.registerMember(jwtBody);
+        boolean isRegistered = authService.registerMember(jwtBody);
         String[] tokenCookies = authService.createTokenCookies(jwtBody);
-        String userInfo = authService.getUserInfo(jwtBody);
+        String userInfo = authService.getUserInfo(jwtBody, isRegistered);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, tokenCookies[0])

--- a/backend/src/main/java/com/bootme/auth/service/AuthService.java
+++ b/backend/src/main/java/com/bootme/auth/service/AuthService.java
@@ -254,7 +254,7 @@ public class AuthService {
     /**
      * 가입된 유저는 방문 횟수를 증가, 가입되지 않은 유저는 가입
      * */
-    public void registerMember(JwtVo.Body jwtBody) throws Exception {
+    public boolean registerMember(JwtVo.Body jwtBody) throws Exception {
         boolean isRegistered = memberService.isMemberRegistered(jwtBody.getEmail());
 
         if (isRegistered) {
@@ -266,6 +266,7 @@ public class AuthService {
             Member member = Member.of(jwtBody);
             memberRepository.save(member);
         }
+        return isRegistered;
     }
 
     // todo: 세션 카운트로 수정해야할듯
@@ -300,18 +301,18 @@ public class AuthService {
     /**
      * 프론트엔드의 헤더와 메뉴 모달, 유저 드롭다운 컴포넌트에 사용될 유저정보를 전달
      * */
-    public String getUserInfo(JwtVo.Body jwtBody) {
+    public String getUserInfo(JwtVo.Body jwtBody, boolean isRegistered) {
         Long memberId = memberService.findByEmail(jwtBody.getEmail()).getId();
         String nickname = jwtBody.getNickname();
         String name = jwtBody.getName();
         String idInEmail = jwtBody.getEmail().split("@")[0];
 
         if (nickname != null) {
-            return "MemberId=" + memberId + ", NickName=" + nickname + ", ProfileImage=" + jwtBody.getPicture();
+            return "IsNewMember=" + !isRegistered + ", MemberId=" + memberId + ", NickName=" + nickname + ", ProfileImage=" + jwtBody.getPicture();
         } else if (name != null) {
-            return "MemberId=" + memberId + ", NickName=" + name + ", ProfileImage=" + jwtBody.getPicture();
+            return "IsNewMember=" + !isRegistered + ", MemberId=" + memberId + ", NickName=" + name + ", ProfileImage=" + jwtBody.getPicture();
         } else
-            return "MemberId=" + memberId + ", NickName=" + idInEmail + ", ProfileImage=" + jwtBody.getPicture();
+            return "IsNewMember=" + !isRegistered + ", MemberId=" + memberId + ", NickName=" + idInEmail + ", ProfileImage=" + jwtBody.getPicture();
     }
 
 }

--- a/backend/src/main/java/com/bootme/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/bootme/common/exception/ErrorType.java
@@ -23,11 +23,11 @@ public enum ErrorType {
     INVALID_EVENT           (UNAUTHORIZED, 1010, "유효하지 않은 webhook 이벤트입니다."),
 
     NOT_FOUND_COURSE        (BAD_REQUEST,  3001, "존재하지 않는 코스입니다."),
-    NOT_FOUND_MEMBER        (BAD_REQUEST,  3002, "존재하지 않는 회원입니다."),
-    NOT_FOUND_BOOKMARK      (BAD_REQUEST,  3003, "해당 북마크 코스가 존재하지 않습니다."),
-    ALREADY_BOOKMARKED      (BAD_REQUEST,  3004, "이미 북마크 저장된 코스입니다.."),
-
-    NOT_FOUND_COMPANY       (BAD_REQUEST,  4001, "존재하지 않는 회사입니다.");
+    NOT_FOUND_COMPANY       (BAD_REQUEST,  4001, "존재하지 않는 회사입니다."),
+    NOT_FOUND_MEMBER        (BAD_REQUEST,  5002, "존재하지 않는 회원입니다."),
+    NOT_FOUND_BOOKMARK      (BAD_REQUEST,  6003, "해당 북마크 코스가 존재하지 않습니다."),
+    ALREADY_BOOKMARKED      (BAD_REQUEST,  6004, "이미 북마크 저장된 코스입니다."),
+    NOT_FOUND_EVENT         (BAD_REQUEST,  7005, "존재하지 않는 알림 이벤트입니다.");
 
     final HttpStatus httpStatus;
     final int errorCode;

--- a/backend/src/main/java/com/bootme/course/domain/Course.java
+++ b/backend/src/main/java/com/bootme/course/domain/Course.java
@@ -63,6 +63,8 @@ public class Course extends BaseEntity {
 
     private boolean isTested;
 
+    private boolean isRegisterOpen;
+
     private int clicks;
 
     private int bookmarks;
@@ -91,6 +93,7 @@ public class Course extends BaseEntity {
         this.isTested = isTested;
         this.clicks = clicks;
         this.bookmarks = bookmarks;
+        this.isRegisterOpen = checkRegisterOpen();
     }
 
     public static Course of(CourseRequest courseRequest, Company company, Category categories, Stack stacks) {
@@ -156,7 +159,7 @@ public class Course extends BaseEntity {
         this.company = company;
     }
 
-    public boolean isRegisterOpen() {
+    public boolean checkRegisterOpen() {
         boolean afterStart = LocalDate.now().isEqual(dates.getRegistrationStartDate()) || LocalDate.now().isAfter(dates.getRegistrationStartDate());
         boolean beforeEnd = LocalDate.now().isEqual(dates.getRegistrationEndDate()) || LocalDate.now().isBefore(dates.getRegistrationEndDate());
         return afterStart && beforeEnd;

--- a/backend/src/main/java/com/bootme/course/domain/Dates.java
+++ b/backend/src/main/java/com/bootme/course/domain/Dates.java
@@ -19,10 +19,19 @@ public class Dates {
     private LocalDate courseEndDate;
 
     @Builder
-    public Dates(LocalDate registrationStartDate, LocalDate registrationEndDate, LocalDate courseStartDate, LocalDate courseEndDate, boolean isOpen, Long coursePeriod) {
+    public Dates(LocalDate registrationStartDate, LocalDate registrationEndDate, LocalDate courseStartDate, LocalDate courseEndDate) {
         this.registrationStartDate = registrationStartDate;
         this.registrationEndDate = registrationEndDate;
         this.courseStartDate = courseStartDate;
         this.courseEndDate = courseEndDate;
     }
+
+    public boolean isRegistrationStartsOn(LocalDate date) {
+        return registrationStartDate.equals(date);
+    }
+
+    public boolean isRegistrationEndsOn(LocalDate date) {
+        return registrationEndDate.equals(date);
+    }
+
 }

--- a/backend/src/main/java/com/bootme/course/repository/CourseRepository.java
+++ b/backend/src/main/java/com/bootme/course/repository/CourseRepository.java
@@ -21,4 +21,9 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     @Query("UPDATE Course c SET c.bookmarks = c.bookmarks + 1 WHERE c.id = :id")
     void incrementBookmarks(@Param("id") Long id);
 
+    @Modifying
+    @Transactional
+    @Query("UPDATE Course c SET c.isRegisterOpen = :isOpen WHERE c.id = :id")
+    void updateIsRegisterOpen(@Param("id") Long id, @Param("isOpen") boolean isOpen);
+
 }

--- a/backend/src/main/java/com/bootme/course/scheduler/CourseScheduler.java
+++ b/backend/src/main/java/com/bootme/course/scheduler/CourseScheduler.java
@@ -1,0 +1,86 @@
+package com.bootme.course.scheduler;
+
+import com.bootme.course.domain.Course;
+import com.bootme.course.repository.CourseRepository;
+import com.bootme.member.domain.BookmarkCourse;
+import com.bootme.member.domain.Member;
+import com.bootme.member.repository.BookmarkCourseRepository;
+import com.bootme.notification.domain.Notification;
+import com.bootme.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@RequiredArgsConstructor
+@Component
+public class CourseScheduler {
+
+    private final CourseRepository courseRepository;
+    private final BookmarkCourseRepository bookmarkCourseRepository;
+    private final NotificationRepository notificationRepository;
+
+    @Scheduled(cron = "00 55 09 * * *", zone = "Asia/Seoul")
+    public void updateIsRegisterOpen() {
+        Iterable<Course> courses = courseRepository.findAll();
+        for (Course course : courses) {
+            boolean updatedStatus = course.checkRegisterOpen();
+            if (course.isRegisterOpen() != updatedStatus) {
+                courseRepository.updateIsRegisterOpen(course.getId(), updatedStatus);
+            }
+        }
+    }
+
+    @Scheduled(cron = "00 00 10 * * *", zone = "Asia/Seoul")
+    public void notifyCourseRegistrationStart() {
+        final String EVENT = "registrationStart";
+        LocalDate now = LocalDate.now();
+        Iterable<BookmarkCourse> bookmarkCourses = bookmarkCourseRepository.findAll();
+
+        for (BookmarkCourse bookmarkCourse : bookmarkCourses) {
+            Member member = bookmarkCourse.getMember();
+            Course course = bookmarkCourse.getCourse();
+            boolean registrationStartsToday = course.getDates().isRegistrationStartsOn(now);
+            if (registrationStartsToday) {
+                Notification notification = Notification.of(member, EVENT, bookmarkCourse);
+                notificationRepository.save(notification);
+            }
+        }
+    }
+
+    @Scheduled(cron = "00 00 10 * * *", zone = "Asia/Seoul")
+    public void notifyCourseRegistrationEndInThreeDays() {
+        final String EVENT = "registrationEndInThreeDays";
+        LocalDate threeDaysLater = LocalDate.now().plusDays(3);
+        Iterable<BookmarkCourse> bookmarkCourses = bookmarkCourseRepository.findAll();
+
+        for (BookmarkCourse bookmarkCourse : bookmarkCourses) {
+            Member member = bookmarkCourse.getMember();
+            Course course = bookmarkCourse.getCourse();
+            boolean registrationEndsInThreeDays = course.getDates().isRegistrationEndsOn(threeDaysLater);
+            if (registrationEndsInThreeDays) {
+                Notification notification = Notification.of(member, EVENT, bookmarkCourse);
+                notificationRepository.save(notification);
+            }
+        }
+    }
+
+    @Scheduled(cron = "00 00 10 * * *", zone = "Asia/Seoul")
+    public void notifyCourseRegistrationEnd() {
+        final String EVENT = "registrationEnd";
+        LocalDate now = LocalDate.now();
+        Iterable<BookmarkCourse> bookmarkCourses = bookmarkCourseRepository.findAll();
+
+        for (BookmarkCourse bookmarkCourse : bookmarkCourses) {
+            Member member = bookmarkCourse.getMember();
+            Course course = bookmarkCourse.getCourse();
+            boolean registrationEndsToday = course.getDates().isRegistrationEndsOn(now);
+            if (registrationEndsToday) {
+                Notification notification = Notification.of(member, EVENT, bookmarkCourse);
+                notificationRepository.save(notification);
+            }
+        }
+    }
+
+}

--- a/backend/src/main/java/com/bootme/member/domain/Member.java
+++ b/backend/src/main/java/com/bootme/member/domain/Member.java
@@ -2,11 +2,14 @@ package com.bootme.member.domain;
 
 import com.bootme.auth.dto.JwtVo;
 import com.bootme.common.domain.BaseEntity;
+import com.bootme.notification.domain.Notification;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -42,6 +45,9 @@ public class Member extends BaseEntity {
 
     private String phoneNumber;
 
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Notification> notifications = new ArrayList<>();
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private RoleType roleType;
@@ -52,7 +58,7 @@ public class Member extends BaseEntity {
     @Builder
     public Member(String email, String password, String OAuthProvider, String name, String profileImage,
                   String birthday, String birthYear, String ageRange, String gender, String nickname,
-                  String phoneNumber, RoleType roleType, Long visitsCount) {
+                  String phoneNumber, List<Notification> notifications, RoleType roleType, Long visitsCount) {
         this.email = email;
         this.password = password;
         this.OAuthProvider = OAuthProvider;
@@ -64,6 +70,7 @@ public class Member extends BaseEntity {
         this.gender = gender;
         this.nickname = nickname;
         this.phoneNumber = phoneNumber;
+        this.notifications = notifications;
         this.roleType = roleType;
         this.visitsCount = visitsCount;
     }

--- a/backend/src/main/java/com/bootme/member/service/MemberService.java
+++ b/backend/src/main/java/com/bootme/member/service/MemberService.java
@@ -33,6 +33,12 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
+    public Member findById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new MemberNotFoundException(NOT_FOUND_MEMBER));
+    }
+
+    @Transactional(readOnly = true)
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberNotFoundException(NOT_FOUND_MEMBER));

--- a/backend/src/main/java/com/bootme/notification/controller/NotificationController.java
+++ b/backend/src/main/java/com/bootme/notification/controller/NotificationController.java
@@ -1,0 +1,42 @@
+package com.bootme.notification.controller;
+
+import com.bootme.member.domain.Member;
+import com.bootme.member.service.MemberService;
+import com.bootme.notification.dto.NotificationResponse;
+import com.bootme.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+    public final NotificationService notificationService;
+    public final MemberService memberService;
+
+    @GetMapping("/notifications/{memberId}")
+    public ResponseEntity<List<NotificationResponse>> findNotificationsByMemberId(@PathVariable Long memberId) {
+        List<NotificationResponse> notificationResponseList = notificationService.findByMemberId(memberId);
+        return ResponseEntity.ok().body(notificationResponseList);
+    }
+
+    @PostMapping("/notifications/{memberId}")
+    public ResponseEntity<Void> sendNotification(@PathVariable Long memberId,
+                                                 @RequestParam String event) {
+        Member member = memberService.findById(memberId);
+        Long notificationId = notificationService.sendNotification(member, event);
+        return ResponseEntity.created(URI.create("/notifications/" + notificationId)).build();
+    }
+
+    @PutMapping("/notifications/{memberId}/checked")
+    public ResponseEntity<List<NotificationResponse>> markAllNotificationsAsCheckedForMember(@PathVariable Long memberId) {
+        notificationService.markAllAsCheckedForMember(memberId);
+        List<NotificationResponse> notificationResponseList = notificationService.findByMemberId(memberId);
+        return ResponseEntity.ok().body(notificationResponseList);
+    }
+
+}

--- a/backend/src/main/java/com/bootme/notification/domain/Notification.java
+++ b/backend/src/main/java/com/bootme/notification/domain/Notification.java
@@ -1,0 +1,87 @@
+package com.bootme.notification.domain;
+
+import com.bootme.common.domain.BaseEntity;
+import com.bootme.member.domain.BookmarkCourse;
+import com.bootme.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String event;
+
+    private String message;
+
+    private boolean checked;
+
+    @Builder
+    public Notification(Member member, String event, String message, boolean checked) {
+        this.member = member;
+        this.event = event;
+        this.message = message;
+        this.checked = checked;
+    }
+
+    public static Notification of(Member member, String event){
+        String message;
+        switch (event) {
+            case "signUp":
+                message = "환영합니다! 다양한 소프트웨어 커리큘럼들을 비교하고 선택할 수 있도록 도와드릴게요 :) \uD83D\uDE0A \uD83D\uDE00 \uD83D\uDE04 ☺️";
+                break;
+            default:
+                // todo: 예외 throw
+                message = "";
+                break;
+        }
+        return Notification.builder()
+                .member(member)
+                .event(event)
+                .message(message)
+                .checked(false)
+                .build();
+    }
+
+    public static Notification of(Member member, String event, BookmarkCourse bookmarkCourse){
+        String courseTitle = bookmarkCourse.getCourse().getTitle();
+
+        String message;
+        switch (event) {
+            case "registrationStart":
+                message = "북마크하신 코스 **" + courseTitle + "**의 접수가 시작되었어요. 놓치지 마시고 신청하세요 \uD83D\uDE0A";
+                break;
+            case "registrationEndInThreeDays":
+                message = "북마크하신 코스 **" + courseTitle + "**의 접수 마감이 3일 남았어요. 놓치지 마시고 신청하세요 \uD83D\uDE00";
+                break;
+            case "registrationEnd":
+                message = "북마크하신 코스 **" + courseTitle + "**의 접수 마감일이에요. 놓치지 마시고 신청하세요 \uD83D\uDE04";
+                break;
+            default:
+                // todo: 예외 throw
+                message = "";
+                break;
+        }
+        return Notification.builder()
+                .member(member)
+                .event(event)
+                .message(message)
+                .checked(false)
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/bootme/notification/domain/Notification.java
+++ b/backend/src/main/java/com/bootme/notification/domain/Notification.java
@@ -3,12 +3,15 @@ package com.bootme.notification.domain;
 import com.bootme.common.domain.BaseEntity;
 import com.bootme.member.domain.BookmarkCourse;
 import com.bootme.member.domain.Member;
+import com.bootme.notification.exception.NotificationEventNotFoundException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+
+import static com.bootme.common.exception.ErrorType.NOT_FOUND_EVENT;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -45,9 +48,7 @@ public class Notification extends BaseEntity {
                 message = "환영합니다! 다양한 소프트웨어 커리큘럼들을 비교하고 선택할 수 있도록 도와드릴게요 :) \uD83D\uDE0A \uD83D\uDE00 \uD83D\uDE04 ☺️";
                 break;
             default:
-                // todo: 예외 throw
-                message = "";
-                break;
+                throw new NotificationEventNotFoundException(NOT_FOUND_EVENT);
         }
         return Notification.builder()
                 .member(member)
@@ -72,9 +73,7 @@ public class Notification extends BaseEntity {
                 message = "북마크하신 코스 **" + courseTitle + "**의 접수 마감일이에요. 놓치지 마시고 신청하세요 \uD83D\uDE04";
                 break;
             default:
-                // todo: 예외 throw
-                message = "";
-                break;
+                throw new NotificationEventNotFoundException(NOT_FOUND_EVENT);
         }
         return Notification.builder()
                 .member(member)

--- a/backend/src/main/java/com/bootme/notification/dto/NotificationResponse.java
+++ b/backend/src/main/java/com/bootme/notification/dto/NotificationResponse.java
@@ -1,0 +1,49 @@
+package com.bootme.notification.dto;
+
+import com.bootme.notification.domain.Notification;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Getter
+public class NotificationResponse {
+
+    private Long notificationId;
+    private Long memberId;
+    private String event;
+    private String message;
+    private boolean isChecked;
+    private long createdAt;
+
+    public NotificationResponse(){
+    }
+
+    @Builder
+    public NotificationResponse(Long notificationId, Long memberId, String event, String message,
+                                boolean isChecked, long createdAt) {
+        this.notificationId = notificationId;
+        this.memberId = memberId;
+        this.event = event;
+        this.message = message;
+        this.isChecked = isChecked;
+        this.createdAt = createdAt;
+    }
+
+    public static NotificationResponse of(Notification notification){
+        return NotificationResponse.builder()
+                .notificationId(notification.getId())
+                .memberId(notification.getMember().getId())
+                .event(notification.getEvent())
+                .message(notification.getMessage())
+                .isChecked(notification.isChecked())
+                .createdAt(convertLocalDateTimeToLong(notification.getCreatedAt()))
+                .build();
+    }
+
+    private static long convertLocalDateTimeToLong(LocalDateTime localDateTime){
+        return localDateTime.toInstant(ZoneOffset.ofHours(9)).toEpochMilli();
+    }
+
+}

--- a/backend/src/main/java/com/bootme/notification/exception/NotificationEventNotFoundException.java
+++ b/backend/src/main/java/com/bootme/notification/exception/NotificationEventNotFoundException.java
@@ -1,0 +1,12 @@
+package com.bootme.notification.exception;
+
+import com.bootme.common.exception.BadRequestException;
+import com.bootme.common.exception.ErrorType;
+
+public class NotificationEventNotFoundException extends BadRequestException {
+
+    public NotificationEventNotFoundException(final ErrorType errorType) {
+        super(errorType);
+    }
+
+}

--- a/backend/src/main/java/com/bootme/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/bootme/notification/repository/NotificationRepository.java
@@ -1,0 +1,22 @@
+package com.bootme.notification.repository;
+
+import com.bootme.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("SELECT n FROM Notification n WHERE n.member.id = :memberId")
+    List<Notification> findByMemberId(@Param("memberId") Long memberId);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Notification n SET n.checked = true WHERE n.member.id = :memberId")
+    void markAllAsCheckedForMember(@Param("memberId") Long memberId);
+
+}

--- a/backend/src/main/java/com/bootme/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/bootme/notification/service/NotificationService.java
@@ -1,0 +1,36 @@
+package com.bootme.notification.service;
+
+import com.bootme.member.domain.Member;
+import com.bootme.notification.domain.Notification;
+import com.bootme.notification.dto.NotificationResponse;
+import com.bootme.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> findByMemberId(Long memberId){
+        List<Notification> notificationList = notificationRepository.findByMemberId(memberId);
+        return notificationList.stream().map(NotificationResponse::of).collect(Collectors.toList());
+    }
+
+    public Long sendNotification(Member member, String event){
+        Notification notification = Notification.of(member, event);
+        return notificationRepository.save(notification).getId();
+    }
+
+    public void markAllAsCheckedForMember(Long memberId) {
+        notificationRepository.markAllAsCheckedForMember(memberId);
+    }
+
+}

--- a/backend/src/test/java/com/bootme/util/fixture/CourseFixture.java
+++ b/backend/src/test/java/com/bootme/util/fixture/CourseFixture.java
@@ -43,10 +43,10 @@ public class CourseFixture {
     public static final int VALID_PERIOD_2 = 28;
     public static final int VALID_PERIOD_3 = 210;
     public static final Dates VALID_DATES_1 = Dates.builder()
-            .registrationStartDate(LocalDate.of(2021, 1, 1))
-            .registrationEndDate(LocalDate.of(2021, 1, 31))
-            .courseStartDate(LocalDate.of(2021, 2, 1))
-            .courseEndDate(LocalDate.of(2021, 4, 30))
+            .registrationStartDate(LocalDate.of(2023, 1, 1))
+            .registrationEndDate(LocalDate.of(2024, 1, 31))
+            .courseStartDate(LocalDate.of(2024, 2, 1))
+            .courseEndDate(LocalDate.of(2024, 4, 30))
             .build();
     public static final Dates VALID_DATES_2 = Dates.builder()
             .registrationStartDate(LocalDate.of(2022, 1, 1))
@@ -55,10 +55,10 @@ public class CourseFixture {
             .courseEndDate(LocalDate.of(2022, 2, 28))
             .build();
     public static final Dates VALID_DATES_3 = Dates.builder()
-            .registrationStartDate(LocalDate.of(2023, 1, 1))
-            .registrationEndDate(LocalDate.of(2023, 1, 31))
-            .courseStartDate(LocalDate.of(2023, 2, 1))
-            .courseEndDate(LocalDate.of(2023, 7, 31))
+            .registrationStartDate(LocalDate.of(2023, 2, 23))
+            .registrationEndDate(LocalDate.of(2024, 1, 1))
+            .courseStartDate(LocalDate.of(2024, 2, 1))
+            .courseEndDate(LocalDate.of(2024, 7, 31))
             .build();
     public static final String VALID_ONOFFLINE_1 = "온라인";
     public static final String VALID_ONOFFLINE_2 = "오프라인";


### PR DESCRIPTION
<h2><strong>Notification Entity Class</strong></h2>


Type | Field Name | Relationship
-- | -- | --
Long | id |  
Member | member | @ManyToOne
String | event |  
String | message |  
boolean | checked |  
LocalDateTime | createdAt |  
LocalDateTime | modifiedAt |  

<br>

<h2><strong>Notification API Endpoints</strong></h2>


HTTP Method | Endpoint | 응답 바디 | 설명
-- | -- | -- | --
GET | /notifications/{memberId} | List of NotificationResponse | 해당 회원의 알림을 반환함
POST | /notifications/{memberId} | Void | 해당 회원에게 알림을 전송함(Notification 아이템을 저장함)
PUT | /notifications/{memberId}/checked | List of NotificationResponse | 해당 멤버의 모든 알림을 확인 처리하고 해당 멤버의 모든 알림 목록을 반환함


<br>

<h2>CourseScheduler</h2>


메서드 | 설명 | 실행 시각
-- | -- | --
updateIsRegisterOpen() | 모든 Course 엔티티의 접수중 여부를 업데이트함 | 매일 9시 55분
notifyCourseRegistrationStart() | 오늘부터 수강 접수가 시작되는 코스가 있다면, 해당 코스를 북마크한 모든 회원에게 알림을 보냄 | 매일 10시
notifyCourseRegistrationEndInThreeDays() | 3일 후에 수강 접수가 마감되는 코스가 있다면, 해당 코스를 북마크한 모든 회원에게 알림을 보냄 | 매일 10시
notifyCourseRegistrationEnd() | 오늘 수강 접수가 마감되는 코스가 있다면, 해당 코스를 북마크한 모든 회원에게 알림을 보냄 | 매일 10시

<br>



## 알림 전송 방식 결정
- 알림을 실시간으로 전송하기 위해 `Message Queue`, `Websockets` 방식 차례로 구현 시도했지만 현재 필요한 기능에 비해 overkill 이거나 구현이 매우 복잡해서 실시간 전송을 포기하고 일반 REST API 와 Scheduling을 결합하여 구현함

<br>


### 알림 전송 방법 결정시 고려한 옵션들
Option | Description | Pros | Cons
-- | -- | -- | --
REST API polling | The frontend periodically sends requests to the backend to check for updates. | Easy to implement, widely used. | Polling can be inefficient and put unnecessary strain on the backend. Not truly real-time.
Message queues | The frontend subscribes to a message queue, and the backend pushes updates to the queue. | Scalable, asynchronous, fault-tolerant. | More complex to implement than polling or traditional REST APIs. Requires a message broker.
WebSockets | A persistent, bidirectional connection is established between the frontend and backend, allowing for real-time communication. | Low latency, efficient, true real-time communication. | More complex to implement than polling or traditional REST APIs.
Realtime frameworks (e.g. Firebase Realtime Database) | Realtime frameworks provide a backend-as-a-service that includes support for real-time data synchronization between clients. | Easy to implement, provides a range of real-time features out-of-the-box. | Can be less flexible than implementing your own solution. May require payment for more advanced features.
Push notifications | The backend sends push notifications to the frontend via a third-party push notification service. | Works even when the app is closed, cross-platform. | Requires a third-party service. More complex to implement than other options.

<br>


### 스케줄링 구현시 고려한 옵션들 (Java, Spring Boot)

Option | Description | Pros | Cons
-- | -- | -- | --
Spring's @Scheduled Annotation | Built-in way to schedule tasks using the @Scheduled annotation. | Simple to use, no additional libraries needed. | Limited scheduling options compared to other libraries. May not be suitable for complex scheduling needs.
Quartz Scheduler | A popular open-source job scheduling library that provides advanced scheduling features. | Supports complex scheduling expressions, distributed scheduling, and more fine-grained control over scheduling than @Scheduled. | More complex to set up and use than @Scheduled. Requires additional configuration and dependencies.
Java Timer | The java.util.Timer class can be used to schedule tasks to run periodically. | Simple to use, built into the Java Standard Library. | Limited scheduling options compared to other libraries. May not be suitable for complex scheduling needs.
ScheduledExecutorService | The ScheduledExecutorService class in the java.util.concurrent package provides a way to schedule tasks to run periodically. | More fine-grained control over scheduling than @Scheduled. Supports fixed-rate and fixed-delay scheduling. | More complex to use than @Scheduled.

- `@Scheduled` 사용이 간단한 기능 구현에 적합하다고 판단하여 선택



***

close #190 







