### PR TITLE
[BE] GlobalExceptionHandler 개선

### DIFF
--- a/backend/src/main/java/com/bootme/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/bootme/common/exception/ErrorType.java
@@ -2,34 +2,30 @@ package com.bootme.common.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-
-import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @RequiredArgsConstructor
 public enum ErrorType {
 
-/*  Error Name               HTTP Status    Error Code     Error Message                  */
-    NOT_AUTHENTICATED       (UNAUTHORIZED, 1001, "인증에 실패했습니다."),
-    ALREADY_AUTHENTICATED   (UNAUTHORIZED, 1002, "이미 인증정보가 존재합니다."),
-    INVALID_TOKEN           (BAD_REQUEST,  1003, "유효하지 않은 토큰입니다."),
-    FORBIDDEN_REQUEST       (FORBIDDEN,    1004, "권한이 없습니다."),
-    INVALID_ISSUER          (UNAUTHORIZED, 1005, "유효하지 않은 토큰 발급자입니다."),
-    INVALID_AUDIENCE        (UNAUTHORIZED, 1006, "토큰의 Audience 값이 유효하지 않습니다."),
-    INVALID_ISSUED_AT       (UNAUTHORIZED, 1007, "토큰의 발행시간이 올바르지 않습니다."),
-    TOKEN_EXPIRED           (UNAUTHORIZED, 1008, "토큰이 만료되었습니다."),
-    INVALID_SIGNATURE       (UNAUTHORIZED, 1009, "토큰이 서명이 올바르지 않습니다."),
-    INVALID_EVENT           (UNAUTHORIZED, 1010, "유효하지 않은 webhook 이벤트입니다."),
+/*  Error Name               Error Code     Error Message                  */
+    NOT_AUTHENTICATED       (1001, "인증에 실패했습니다."),
+    ALREADY_AUTHENTICATED   (1002, "이미 인증정보가 존재합니다."),
+    INVALID_TOKEN           (1003, "유효하지 않은 토큰입니다."),
+    FORBIDDEN_REQUEST       (1004, "권한이 없습니다."),
+    INVALID_ISSUER          (1005, "유효하지 않은 토큰 발급자입니다."),
+    INVALID_AUDIENCE        (1006, "토큰의 Audience 값이 유효하지 않습니다."),
+    INVALID_ISSUED_AT       (1007, "토큰의 발행시간이 올바르지 않습니다."),
+    TOKEN_EXPIRED           (1008, "토큰이 만료되었습니다."),
+    INVALID_SIGNATURE       (1009, "토큰이 서명이 올바르지 않습니다."),
+    INVALID_EVENT           (1010, "유효하지 않은 webhook 이벤트입니다."),
 
-    NOT_FOUND_COURSE        (BAD_REQUEST,  3001, "존재하지 않는 코스입니다."),
-    NOT_FOUND_COMPANY       (BAD_REQUEST,  4001, "존재하지 않는 회사입니다."),
-    NOT_FOUND_MEMBER        (BAD_REQUEST,  5002, "존재하지 않는 회원입니다."),
-    NOT_FOUND_BOOKMARK      (BAD_REQUEST,  6003, "해당 북마크 코스가 존재하지 않습니다."),
-    ALREADY_BOOKMARKED      (BAD_REQUEST,  6004, "이미 북마크 저장된 코스입니다."),
-    NOT_FOUND_EVENT         (BAD_REQUEST,  7005, "존재하지 않는 알림 이벤트입니다.");
+    NOT_FOUND_COURSE        (3001, "존재하지 않는 코스입니다."),
+    NOT_FOUND_COMPANY       (4001, "존재하지 않는 회사입니다."),
+    NOT_FOUND_MEMBER        (5002, "존재하지 않는 회원입니다."),
+    NOT_FOUND_BOOKMARK      (6003, "해당 북마크 코스가 존재하지 않습니다."),
+    ALREADY_BOOKMARKED      (6004, "이미 북마크 저장된 코스입니다."),
+    NOT_FOUND_EVENT         (7005, "존재하지 않는 알림 이벤트입니다.");
 
-    final HttpStatus httpStatus;
     final int errorCode;
     final String message;
 

--- a/backend/src/main/java/com/bootme/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/bootme/common/exception/ErrorType.java
@@ -24,7 +24,9 @@ public enum ErrorType {
     NOT_FOUND_MEMBER        (5002, "존재하지 않는 회원입니다."),
     NOT_FOUND_BOOKMARK      (6003, "해당 북마크 코스가 존재하지 않습니다."),
     ALREADY_BOOKMARKED      (6004, "이미 북마크 저장된 코스입니다."),
-    NOT_FOUND_EVENT         (7005, "존재하지 않는 알림 이벤트입니다.");
+    NOT_FOUND_EVENT         (7005, "존재하지 않는 알림 이벤트입니다."),
+
+    RUNTIME_EXCEPTION       (8001, "서버에 알 수 없는 문제가 발생했습니다.");
 
     final int errorCode;
     final String message;

--- a/backend/src/main/java/com/bootme/common/exception/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/bootme/common/exception/dto/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.bootme.common.exception.dto;
 
+import com.bootme.common.exception.ErrorType;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,4 +22,12 @@ public class ErrorResponse {
                 ", message='" + message + '\'' +
                 '}';
     }
+
+    public static ErrorResponse of(ErrorType errorType){
+        return ErrorResponse.builder().
+                errorCode(errorType.getErrorCode()).
+                message(errorType.getMessage()).
+                build();
+    }
+
 }

--- a/backend/src/main/java/com/bootme/common/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/bootme/common/exception/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.bootme.common.exception.ForbiddenException;
 import com.bootme.common.exception.dto.ErrorResponse;
 import com.bootme.common.exception.ErrorType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -19,25 +20,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> badRequestExceptionHandler(final BadRequestException e) {
         log.warn("Bad Request Exception", e);
         ErrorType errorType = e.getErrorType();
-        return handleExceptionInternal(errorType);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(makeErrorResponse(errorType));
     }
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ErrorResponse> unauthorizedExceptionHandler(final UnauthorizedException e) {
         log.warn("Unauthorized Exception", e);
         ErrorType errorType = e.getErrorType();
-        return handleExceptionInternal(errorType);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(makeErrorResponse(errorType));
     }
 
     @ExceptionHandler(ForbiddenException.class)
     public ResponseEntity<ErrorResponse> forbiddenExceptionHandler(final ForbiddenException e) {
         log.warn("Forbidden Exception", e);
         ErrorType errorType = e.getErrorType();
-        return handleExceptionInternal(errorType);
-    }
-
-    private ResponseEntity<ErrorResponse> handleExceptionInternal(ErrorType errorType) {
-        return ResponseEntity.status(errorType.getHttpStatus()).body(makeErrorResponse(errorType));
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(makeErrorResponse(errorType));
     }
 
     private ErrorResponse makeErrorResponse(ErrorType errorType) {

--- a/backend/src/main/java/com/bootme/common/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/bootme/common/exception/handler/GlobalExceptionHandler.java
@@ -20,28 +20,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> badRequestExceptionHandler(final BadRequestException e) {
         log.warn("Bad Request Exception", e);
         ErrorType errorType = e.getErrorType();
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(makeErrorResponse(errorType));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(errorType));
     }
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ErrorResponse> unauthorizedExceptionHandler(final UnauthorizedException e) {
         log.warn("Unauthorized Exception", e);
         ErrorType errorType = e.getErrorType();
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(makeErrorResponse(errorType));
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse.of(errorType));
     }
 
     @ExceptionHandler(ForbiddenException.class)
     public ResponseEntity<ErrorResponse> forbiddenExceptionHandler(final ForbiddenException e) {
         log.warn("Forbidden Exception", e);
         ErrorType errorType = e.getErrorType();
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(makeErrorResponse(errorType));
-    }
-
-    private ErrorResponse makeErrorResponse(ErrorType errorType) {
-        return ErrorResponse.builder().
-                errorCode(errorType.getErrorCode()).
-                message(errorType.getMessage()).
-                build();
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse.of(errorType));
     }
 
 }

--- a/backend/src/main/java/com/bootme/common/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/bootme/common/exception/handler/GlobalExceptionHandler.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import static com.bootme.common.exception.ErrorType.RUNTIME_EXCEPTION;
+
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
@@ -35,6 +37,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn("Forbidden Exception", e);
         ErrorType errorType = e.getErrorType();
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse.of(errorType));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
+        log.warn("Runtime Exception", e);
+        return ResponseEntity.internalServerError().body(ErrorResponse.of(RUNTIME_EXCEPTION));
     }
 
 }


### PR DESCRIPTION
## 1. ExceptionHandler 메서드 리턴문에서 HttpStatus 표시되도록 변경

### AS-IS
```java
    @ExceptionHandler(BadRequestException.class)
    public ResponseEntity<ErrorResponse> badRequestExceptionHandler(final BadRequestException e) {
        log.warn("Bad Request Exception", e);
        ErrorType errorType = e.getErrorType();
        return handleExceptionInternal(errorType);
    }
```
- 핸들러 메서드만 보고 어떤 HTTP Stauts 반환되는지 알 수 없음
- ErrorType Enum 클래스에 가서 각 에러에 맞는 HTTP Status 가 무엇인지 확인해야하는 번거로움 있음

<br>

### TO-BE
```java
    @ExceptionHandler(BadRequestException.class)
    public ResponseEntity<ErrorResponse> badRequestExceptionHandler(final BadRequestException e) {
        log.warn("Bad Request Exception", e);
        ErrorType errorType = e.getErrorType();
        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(makeErrorResponse(errorType));
    }
```
- return statement에 HTTP Status 값이 포함되어 보다 명확하게 어떤 HTTP Status가 반환되는지 알 수 있음

<br>


## 2.GlobalExceptionHandler 에서 ErrorResponse 팩토리 메서드 제거

### AS-IS
```java
    private ErrorResponse makeErrorResponse(ErrorType errorType) {
        return ErrorResponse.builder().
                errorCode(errorType.getErrorCode()).
                message(errorType.getMessage()).
                build();
    }
```
- GlobalExceptionHandler 클래스에 ErrorResponse 팩토리 메서드가 있음

<br>

### TO-BE
```java
    public static ErrorResponse of(String message){
        return ErrorResponse.builder().
                message(message).
                build();
    }
```
- ErrorResponse 클래스에 팩토리 메서드 of() 구현하고 GlobalExceptionHandler 클래스에서 사용하도록 변경함
- GlobalExceptionHandler 클래스의 코드 간소화
- 이후 ErrorResponse 변경사항 발생시 해당 클래스 내에서 관련 변경사항 처리가능

<br>

## 3. 런타임 예외 핸들러 메서드 추가
```java
    @ExceptionHandler(RuntimeException.class)
    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
        log.warn("Runtime Exception", e);
        return ResponseEntity.internalServerError().body(ErrorResponse.of(RUNTIME_EXCEPTION));
    }
```

<br>



***

close #196 








