### PR TITLE
[FE] 프론트엔드 CI/CD 적용

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,0 +1,64 @@
+name: frontend deployment
+
+on:
+  push:
+    branches: [main]
+    paths: ["frontend/**"]
+
+defaults:
+  run:
+    working-directory: frontend
+
+env:
+  S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME_FRONTEND }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # 소스 코드의 string 을 깃허브 리포지토리 시크릿에 저장된 값으로 교체
+      #   aws-sdk 자격증명을 위한 시크릿: IAM 사용자 aws_sdk_credentials_client-secrets-manager 엑세스 키, 시크릿 키 사용
+      #   구글 클라이언트 아이디는 동시성 문제로 AWS Secrets Manager 값을 사용하지 않고 리포지토리 시크릿에 값을 저장하여 교체함
+      #     src/index.tsx 에서는 동시성 문제로 useSecret 의 시크릿 값을 사용하기 번거로워서 사용하지 않고 리포지토리 시크릿을 사용함
+      - name: Replace secrets
+        run: |
+          sed -i "s/AWS_SDK_CREDENTIAL_ACCESS_KEY/${{ secrets.AWS_SDK_CREDENTIAL_ACCESS_KEY }}/g" ./src/hooks/useSecret.tsx
+          sed -i "s/AWS_SDK_CREDENTIAL_SECRET_KEY/${{ secrets.AWS_SDK_CREDENTIAL_SECRET_KEY }}/g" ./src/hooks/useSecret.tsx
+          sed -i "s/GOOGLE_CLIENT_ID/${{ secrets.GOOGLE_CLIENT_ID }}/g" ./src/index.tsx
+
+      - name: Install dependencies and Build
+        run: |
+          npm install
+          npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Delete files from S3 root
+        run: |
+          aws s3 rm s3://${S3_BUCKET_NAME}/ --recursive --exclude="naver_logo.svg" --exclude="favicon.ico" --exclude="build/*"
+
+      # 기존 배포파일들을 보관하기 위해 S3 버킷 root 경로에 더해 ./build 폴더에도 빌드파일 저장
+      - name: Create new folder in S3 and Upload build files to the folder
+        run: |
+          folder_name=$(TZ=Asia/Seoul date +"%Y%m%d_%H%M%S")_${GITHUB_SHA}
+          aws s3api put-object --bucket ${S3_BUCKET_NAME} --key build/${folder_name}/
+          aws s3 cp dist/ s3://${S3_BUCKET_NAME}/build/${folder_name}/ --recursive
+
+      - name: Upload new build files to S3 bucket root
+        run: |
+          aws s3 cp dist/ s3://${S3_BUCKET_NAME}/ --recursive
+          sleep 10
+
+      # 새로 업로드 된 index.html 파일을 호스팅 하도록 CloudFront 캐시 삭제
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'


### PR DESCRIPTION
<h2> 깃허브 액션 워크플로우로 CI/CD 적용</h3>

- 프론트엔드 프로젝트에 push 발생시 새로운 빌드파일(index.html, main.js)을 S3에 업로드 하고 해당 파일을 CloudFront에서 호스팅 하도록 설정함

<br>

<h2>프로트엔드 CI/CD 워크플로우 각 Step 작업 설명</h3>
<ul>
<li><code>.github/workflows/frontend-deploy.yml</code> 의 작업 단위 중 특이 사항들</li>
</ul>

<br>


<h3><strong>1. Replace secrets</strong></h3>
<pre><code class="language-yaml">- name: Replace secrets
      run: |
        sed -i &quot;s/AWS_SDK_CREDENTIAL_ACCESS_KEY/${{ secrets.AWS_SDK_CREDENTIAL_ACCESS_KEY }}/g&quot; ./src/hooks/useSecret.tsx
        sed -i &quot;s/AWS_SDK_CREDENTIAL_SECRET_KEY/${{ secrets.AWS_SDK_CREDENTIAL_SECRET_KEY }}/g&quot; ./src/hooks/useSecret.tsx
        sed -i &quot;s/GOOGLE_CLIENT_ID/${{ secrets.GOOGLE_CLIENT_ID }}/g&quot; ./src/index.tsx
</code></pre>
<ul>
<li>
<p>빌드 전에 소스 코드의 string 을 깃허브 리포지토리 시크릿에 저장된 값으로 교체함</p>


No. | 교체 대상 string | 교체 대상 string 경로 | 시크릿 목적 | 시크릿 출처
-- | -- | -- | -- | --
1 | AWS_SDK_CREDENTIAL_ACCESS_KEY | frontend/src/hooks/useSecret.tsx | aws-sdk 자격증명 | AWS IAM 사용자 aws_sdk…
2 | AWS_SDK_CREDENTIAL_SECRET_KEY | frontend/src/hooks/useSecret.tsx | aws-sdk 자격증명 | AWS IAM 사용자 aws_sdk…
3 | GOOGLE_CLIENT_ID | frontend/src/index.tsx | 구글 로그인 사용 | 구글 클라우드 플랫폼 > API & Services > Credentials


<ul>
<li>위의 string 들은 bootme 리포지토리의 Settings &gt; Secrets and variables &gt; Actions 위치에 저장된 시크릿 값으로 교체됨</li>
<li><code>GOOGLE_CLIENT_ID</code> 값만 리포지토리 시크릿에 저장된 값 사용
<ul>
<li>다른 시크릿 값들은 AWS Secrets Manager 로 가져와서 사용함 (useSecret 커스텀 훅 사용)</li>
<li><code>frontend/src/index.tsx</code> 경로에서는 동시성 문제로 useSecret 훅에서 시크릿을 가져와서 사용하기 번거롭기 때문에</li>
</ul>
</li>
</ul>
</li>
</ul>

<br>

<h3>2. Create new folder in S3 and Upload build files to the folder</h3>
<pre><code class="language-yaml">- name: Create new folder in S3 and Upload build files to the folder
      run: |
        folder_name=$(TZ=Asia/Seoul date +&quot;%Y%m%d_%H%M%S&quot;)_${GITHUB_SHA}
        aws s3api put-object --bucket ${S3_BUCKET_NAME} --key build/${folder_name}/
        aws s3 cp dist/ s3://${S3_BUCKET_NAME}/build/${folder_name}/ --recursive
</code></pre>
<ul>
<li>
<p>추후 빌드파일 히스토리 확인 위해 새로운 빌드파일을 따로 저장</p>

![image](https://user-images.githubusercontent.com/44575214/224726114-baaaf8f5-bf71-43cd-b779-dbd4967d80e4.png)


<ul>
<li>S3 버킷의 /build 경로에 현재 시간과 커밋 해시값을 이름으로 하는 폴더를 생성</li>
<li>해당 폴더에 새로운 빌드 파일을 업로드</li>
</ul>
</li>
</ul>

<br>

<h3>3. Invalidate CloudFront cache</h3>
<pre><code class="language-yaml">- name: Invalidate CloudFront cache
      run: |
        aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'
</code></pre>
<ul>
<li>S3 버킷 루트 경로에 새로 업로드 된 index.html 파일이 호스팅 되도록 CloudFront 캐시 삭제</li>
<li>CloudFront 캐시를 삭제 하지 않으면 캐싱된 기존의 index.html 파일이 계속해서 호스팅되기 때문에</li>
</ul>




<br>







