### PR TITLE
[FE] 네이버 로그인 문제 해결

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Home from './pages/Home';
 import { Route, Routes } from 'react-router-dom';
 import PATH from './constants/path';
+import { NaverLoginRedirect } from './components/LoginModal/NaverLogin';
 import { KakaoLoginRedirect } from './components/LoginModal/KakaoLogin';
 import Bookmarks from './pages/Bookmarks';
 import PrivateRoute from './routes/PrivateRoute';
@@ -13,6 +14,7 @@ const App = () => {
     <>
       <Routes>
         <Route path={PATH.HOME} element={<Home />} />
+        <Route path={PATH.OAUTH.NAVER} element={<NaverLoginRedirect />} />
         <Route path={PATH.OAUTH.KAKAO} element={<KakaoLoginRedirect />} />
         <Route path={PATH.LOGIN} element={<Login />} />
         <Route path={'/test'} element={<Test />} />

--- a/frontend/src/components/LoginModal/NaverLogin/index.tsx
+++ b/frontend/src/components/LoginModal/NaverLogin/index.tsx
@@ -10,7 +10,6 @@ export const NaverLoginButton = () => {
   const { secrets } = useSecret();
   const CLIENT_ID = secrets['naver-client-id'];
   const REDIRECT_URL = secrets['naver-redirect-uri'];
-
   const naverLogin = new naver.LoginWithNaverId({
     clientId: CLIENT_ID,
     callbackUrl: REDIRECT_URL,
@@ -19,7 +18,6 @@ export const NaverLoginButton = () => {
     callbackHandle: true,
   });
 
-  const { sendIdTokenToServer, handleLoginSuccess } = useLogin();
   const naverRef = useRef<HTMLDivElement>(null);
   const handleNaverLogin = () => {
     (naverRef.current?.children[0] as HTMLButtonElement).click();
@@ -27,16 +25,6 @@ export const NaverLoginButton = () => {
 
   useEffect(() => {
     naverLogin.init();
-    // todo: getLoginStatus()를 리다이렉트된 페이지에서 호출해야 정상적인데, 그렇게 할 경우 에러 발생
-    naverLogin.getLoginStatus(function (status: never) {
-      if (status) {
-        generateIdToken(naverLogin).then(idToken => {
-          sendIdTokenToServer(idToken).then(() => {
-            handleLoginSuccess('naver');
-          });
-        });
-      }
-    });
   }, []);
 
   return (
@@ -49,32 +37,76 @@ export const NaverLoginButton = () => {
   );
 };
 
-const generateIdToken = async (naverLogin: naverTokenTypes) => {
+export const NaverLoginRedirect = () => {
+  const { sendIdTokenToServer, handleLoginSuccess } = useLogin();
   const { secrets } = useSecret();
-  const ISSUER = secrets['naver-issuer'];
-  const AUDIENCE = secrets['naver-audience'];
-  const SIGNING_KEY = secrets['naver-signing-key'];
-  const alg = 'HS256';
-  const typ = 'JWT';
-  const signingKey = new TextEncoder().encode(SIGNING_KEY);
-  const payload = {
-    ageRange: naverLogin.user.age,
-    birthDay: naverLogin.user.birthday,
-    birthYear: naverLogin.user.birthyear,
-    email: naverLogin.user.email,
-    gender: naverLogin.user.gender,
-    phoneNumber: naverLogin.user.mobile,
-    name: naverLogin.user.name,
-    nickname: naverLogin.user.nickname,
-    picture: naverLogin.user.profile_image,
+  const CLIENT_ID = secrets['naver-client-id'];
+  const REDIRECT_URL = secrets['naver-redirect-uri'];
+
+  const naverLogin = new naver.LoginWithNaverId({
+    clientId: CLIENT_ID,
+    callbackUrl: REDIRECT_URL,
+    isPopup: false,
+    callbackHandle: true,
+  });
+
+  const generateIdToken = async (naverLogin: naverTokenTypes) => {
+    const ISSUER = secrets['naver-issuer'];
+    const AUDIENCE = secrets['naver-audience'];
+    const SIGNING_KEY = secrets['naver-signing-key'];
+    const signingKey = new TextEncoder().encode(SIGNING_KEY);
+
+    const alg = 'HS256';
+    const typ = 'JWT';
+    const payload = {
+      ageRange: naverLogin.user.age,
+      birthDay: naverLogin.user.birthday,
+      birthYear: naverLogin.user.birthyear,
+      email: naverLogin.user.email,
+      gender: naverLogin.user.gender,
+      phoneNumber: naverLogin.user.mobile,
+      name: naverLogin.user.name,
+      nickname: naverLogin.user.nickname,
+      picture: naverLogin.user.profile_image,
+    };
+    return await new jose.SignJWT(payload)
+      .setProtectedHeader({ alg, typ })
+      .setIssuedAt()
+      .setExpirationTime(naverLogin.accessToken.expires)
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .sign(signingKey);
   };
-  return await new jose.SignJWT(payload)
-    .setProtectedHeader({ alg, typ })
-    .setIssuedAt()
-    .setExpirationTime(naverLogin.accessToken.expires)
-    .setIssuer(ISSUER)
-    .setAudience(AUDIENCE)
-    .sign(signingKey);
+
+  /**
+   * <네이버 로그인 처리 과정>
+   *
+   *  [NaverLoginButton]
+   *    1. 사용자가 id="naverIdLogin"인 div element(네이버 로그인버튼) 클릭 -> 네이버 로그인창으로 이동
+   *    2. 사용자가 '아이디'와 '비밀번호'를 입력하고 '로그인' 버튼 클릭 -> 개인정보 제공 동의창으로 이동
+   *    3. 사용자가 '필수 제공 항목'과 '추가 제공 항목'을 선택하고 '동의하기' 버튼 클릭 -> NaverLoginRedirect 페이지로 리다이렉트
+   *
+   *  [NaverLoginRedirect]
+   *    1. naverLogin.init() - 네아로 로그인 정보를 초기화
+   *    2. naverLogin.getLoginStatus() - 로그인한 사용자 정보를 받아옴
+   *    3. generateIdToken() - 사용자 정보를 담은 JWT 생성
+   *    4. sendIdTokenToServer() - 생성한 JWT 토큰을 서버로 전송
+   *    5. handleLoginSuccess() - 서버 로그인 처리 완료 이후 사용자를 Home 페이지로 리다이렉트
+   * */
+  useEffect(() => {
+    naverLogin.init();
+    naverLogin.getLoginStatus(function (status: never) {
+      if (status) {
+        generateIdToken(naverLogin).then(idToken => {
+          sendIdTokenToServer(idToken).then(() => {
+            handleLoginSuccess('naver');
+          });
+        });
+      }
+    });
+  }, [secrets]);
+
+  return <></>;
 };
 
 interface naverTokenTypes {

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -2,6 +2,7 @@ const PATH = {
   HOME: '/',
   LOGIN: '/login',
   OAUTH: {
+    NAVER: '/oauth/naver',
     KAKAO: '/oauth/kakao',
   },
   BOOKMARKS: '/bookmarks',


### PR DESCRIPTION
## 작업 설명
- 기존 네이버 로그인 구현 중 리다이렉트 페이지 구현에서 문제가 있어 로그인 구현 완료하지 못했음
  - 참고: https://github.com/Jinwook94/bootme/pull/105
- 리다이렉트 페이지 구현 문제 해결하여 네이버 로그인 구현 완료
- 추후 로그아웃 등 추가 구현 필요

<br>

## 네이버 로그인 처리 과정

### NaverLoginButton
1. 사용자가 id="naverIdLogin"인 div element(네이버 로그인버튼) 클릭 ➡︎ 네이버 로그인창으로 이동
2. 사용자가 '아이디'와 '비밀번호'를 입력하고 '로그인' 버튼 클릭 ➡︎ 개인정보 제공 동의창으로 이동
3. 사용자가 '필수 제공 항목'과 '추가 제공 항목'을 선택하고 '동의하기' 버튼 클릭 ➡︎ NaverLoginRedirect 페이지로 리다이렉트

<br>

### NaverLoginRedirect
```typescript
   // NaverLogin.index.tsx - NaverLoginRedirect

    ① naverLogin.init();
    ② naverLogin.getLoginStatus(function (status: never) {
      if (status) {
       ③ generateIdToken(naverLogin).then(idToken => {
          ④ sendIdTokenToServer(idToken).then(() => {
            ⑤ handleLoginSuccess('naver');
          });
        });
      }
    });
```

1. naverLogin.init() - 네아로 로그인 정보를 초기화
2. naverLogin.getLoginStatus() - 로그인한 사용자 정보를 받아옴
3. generateIdToken() - 사용자 정보를 담은 JWT 생성
   - 직접 생성한 JWT 이므로 ID 토큰 아니지만 다른 OAuth 로그인과 네이밍 통일하기 위해 IdToken 이라고 네이밍함
   - ID 토큰: OpenID Connect 프로토콜에서 인증정보 제공할 때 사용하는 JWT
5. sendIdTokenToServer() - 생성한 JWT 토큰을 서버로 전송
6. handleLoginSuccess() - 서버 로그인 처리 완료 이후 사용자를 Home 페이지로 리다이렉트

<br>

## 기타 주의 사항
```typescript
  const naverLogin = new naver.LoginWithNaverId({
    clientId: CLIENT_ID,
    callbackUrl: REDIRECT_URL,
    isPopup: false,
    callbackHandle: true,
  });
```
- 리다이렉트 페이지의 naverLogin 객체 초기화 시(new naver.LoginWithNaverId)에는 인자에 'loginButton' 있으면 안됨
- 버튼 요소(id="naverIdLogin")가 없는 컴포넌트에서 naverLogin 초기화 할 때 'loginButton' 인자 포함하면 에러 발생함

<br>
