### PR TITLE
[BE] 웰컴 메시지 알림 전송 로직 변경

### DIFF
--- a/backend/src/main/java/com/bootme/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bootme/auth/controller/AuthController.java
@@ -24,9 +24,9 @@ public class AuthController {
         JwtVo.Body jwtBody = jwtVo.getBody();
 
         authService.verifyToken(idToken);
-        boolean isRegistered = authService.registerMember(jwtBody);
+        authService.registerMember(jwtBody);
         String[] tokenCookies = authService.createTokenCookies(jwtBody);
-        String userInfo = authService.getUserInfo(jwtBody, isRegistered);
+        String userInfo = authService.getUserInfo(jwtBody);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, tokenCookies[0])

--- a/backend/src/main/java/com/bootme/auth/service/AuthService.java
+++ b/backend/src/main/java/com/bootme/auth/service/AuthService.java
@@ -13,6 +13,7 @@ import com.bootme.auth.token.TokenProvider;
 import com.bootme.member.domain.Member;
 import com.bootme.member.repository.MemberRepository;
 import com.bootme.member.service.MemberService;
+import com.bootme.notification.service.NotificationService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -37,6 +38,7 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final MemberService memberService;
     private final TokenProvider tokenProvider;
+    private final NotificationService notificationService;
 
     private final long ACCESS_TOKEN_EXPIRE_TIME_IN_SECONDS;
     private final long REFRESH_TOKEN_EXPIRE_TIME_IN_SECONDS;
@@ -59,6 +61,7 @@ public class AuthService {
     public AuthService(MemberRepository memberRepository,
                        MemberService memberService,
                        TokenProvider tokenProvider,
+                       NotificationService notificationService,
                        @Value("${security.jwt.bootme.exp.second.access}") long ACCESS_TOKEN_EXPIRE_TIME_IN_SECONDS,
                        @Value("${security.jwt.bootme.exp.second.refresh}") long REFRESH_TOKEN_EXPIRE_TIME_IN_SECONDS,
                        @Value("${security.jwt.bootme_front.issuer}") String BOOTME_ISSUER,
@@ -74,6 +77,7 @@ public class AuthService {
         this.memberRepository = memberRepository;
         this.memberService = memberService;
         this.tokenProvider = tokenProvider;
+        this.notificationService = notificationService;
         this.ACCESS_TOKEN_EXPIRE_TIME_IN_SECONDS = ACCESS_TOKEN_EXPIRE_TIME_IN_SECONDS;
         this.REFRESH_TOKEN_EXPIRE_TIME_IN_SECONDS = REFRESH_TOKEN_EXPIRE_TIME_IN_SECONDS;
         this.BOOTME_ISSUER = BOOTME_ISSUER;
@@ -263,7 +267,8 @@ public class AuthService {
             jwtBody.setOAuthProvider(issuer);
 
             Member member = Member.of(jwtBody);
-            memberRepository.save(member);
+            Member savedMember = memberRepository.save(member);
+            notificationService.sendNotification(savedMember, "signUp");
         }
         return isRegistered;
     }

--- a/backend/src/main/java/com/bootme/auth/service/AuthService.java
+++ b/backend/src/main/java/com/bootme/auth/service/AuthService.java
@@ -257,7 +257,7 @@ public class AuthService {
     /**
      * 가입된 유저는 방문 횟수를 증가, 가입되지 않은 유저는 가입
      */
-    public boolean registerMember(JwtVo.Body jwtBody) {
+    public void registerMember(JwtVo.Body jwtBody) {
         boolean isRegistered = memberService.isMemberRegistered(jwtBody.getEmail());
 
         if (isRegistered) {
@@ -270,7 +270,6 @@ public class AuthService {
             Member savedMember = memberRepository.save(member);
             notificationService.sendNotification(savedMember, "signUp");
         }
-        return isRegistered;
     }
 
     private void incrementVisitsCount(JwtVo.Body jwtBody) {
@@ -300,18 +299,18 @@ public class AuthService {
     /**
      * 프론트엔드의 헤더와 메뉴 모달, 유저 드롭다운 컴포넌트에 사용될 유저정보를 전달
      */
-    public String getUserInfo(JwtVo.Body jwtBody, boolean isRegistered) {
+    public String getUserInfo(JwtVo.Body jwtBody) {
         Long memberId = memberService.findByEmail(jwtBody.getEmail()).getId();
         String nickname = jwtBody.getNickname();
         String name = jwtBody.getName();
         String idInEmail = jwtBody.getEmail().split("@")[0];
 
         if (nickname != null) {
-            return "IsNewMember=" + !isRegistered + ", MemberId=" + memberId + ", NickName=" + nickname + ", ProfileImage=" + jwtBody.getPicture();
+            return "MemberId=" + memberId + ", NickName=" + nickname + ", ProfileImage=" + jwtBody.getPicture();
         } else if (name != null) {
-            return "IsNewMember=" + !isRegistered + ", MemberId=" + memberId + ", NickName=" + name + ", ProfileImage=" + jwtBody.getPicture();
+            return "MemberId=" + memberId + ", NickName=" + name + ", ProfileImage=" + jwtBody.getPicture();
         } else
-            return "IsNewMember=" + !isRegistered + ", MemberId=" + memberId + ", NickName=" + idInEmail + ", ProfileImage=" + jwtBody.getPicture();
+            return "MemberId=" + memberId + ", NickName=" + idInEmail + ", ProfileImage=" + jwtBody.getPicture();
     }
 
 }


### PR DESCRIPTION
## 배경
- 웰컴 메시지 알림 전송 로직이 불필요하게 복잡하여 첫 로그인 직후 새로고침 이전까지 알림이 수신되지 않는 문제 발생


<br>

## AS-IS
- 백엔드 회원가입 처리 이후 프론트에서 다시 웰컴 메시지 알림 전송 요청을 백엔드로 보냄
- 이전 구현 참고
  - https://github.com/Jinwook94/bootme/pull/189

<br>

## TO-BE
- 백엔드에서 회원 가입 처리 중 웰컴 메시지 알림 전송까지 처리
- 프론트에서 알림 전송을 요청하는 과정이 사라지며 처리 과정이 단순해짐

<br>