### PR TITLE
[FE] 코스 필터 '수강 비용' 탭에서 무료 옵션 선택 해제시 RangeBar 값 1000으로 입력되도록 변경

### DIFF
--- a/frontend/src/hooks/useRangeBar.tsx
+++ b/frontend/src/hooks/useRangeBar.tsx
@@ -18,7 +18,7 @@ export const useRangeBar = (filterName: string, isReset: boolean) => {
 
   const [currentValue, setCurrentValue] = useState(Filter.maxValue);
   const { selectedFilters, addFilter, removeBeforeAdd, removeFilter } = useFilters();
-  const [, setIsFree] = useState(false);
+  const [isFreeSelected, setIsFreeSelected] = useState(false);
 
   const handleRangeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setCurrentValue(Number(event.target.value));
@@ -53,17 +53,24 @@ export const useRangeBar = (filterName: string, isReset: boolean) => {
       selectedFilters.includes(COST_TYPE.filterName + ':' + COST_TYPE.filterOptions[0]) ||
       selectedFilters.includes(COST_TYPE.filterName + ':' + COST_TYPE.filterOptions[1]);
 
+    setIsFreeSelected(isFreeSelected);
+
     if (isFreeSelected && filterName === COST_TYPE.filterName) {
-      setIsFree(true);
       setCurrentValue(0);
       const costFilters = selectedFilters.filter(filter => filter.startsWith('비용'));
       costFilters.forEach(filter => {
         const [property, value] = filter.split(':');
         removeFilter(property, value);
       });
-      setIsFree(false);
     }
   }, [selectedFilters]);
+
+  // 무료 옵션 해제시 RangeBar 값 1000으로 설정
+  useEffect(() => {
+    if (!isFreeSelected && filterName === COST_TYPE.filterName) {
+      setCurrentValue(1000);
+    }
+  }, [isFreeSelected]);
 
   return { Filter, currentValue, handleRangeChange, handleInputChange };
 };


### PR DESCRIPTION
## 설명
- 코스 필터 '수강 비용' 탭에서 무료 옵션 선택 해제시 RangeBar 값 1000으로 입력되도록 변경

<br>

## AS-IS
### 모바일
![asis_mobile](https://user-images.githubusercontent.com/44575214/225903441-0d87e4b4-ecb9-4d5f-b6cb-d0e411260c7f.gif)

### PC
![asis_pc](https://user-images.githubusercontent.com/44575214/225903289-a517ae3e-df35-43a0-ac80-505e7a68c57b.gif)


- 현재 무료 옵션 선택 해제해도 RangeBar 값이 0으로 유지되고 있음
- 사용자가 다시 RangeBar 값을 조절해야 조절 된 값에 따라 유료 코스들이 조회됨
- 위 과정이 번거로울 수 있으므로 코스 필터 '수강 비용' 탭에서 무료 옵션 선택 해제시 RangeBar 값 1000으로 입력되도록 변경 필요

<br>

## TO-BE
### 모바일
![tobe_mobile](https://user-images.githubusercontent.com/44575214/225904220-94d4e0e0-4038-4937-b325-489290ee1849.gif)

### PC
![tobe_pc](https://user-images.githubusercontent.com/44575214/225904287-2228c474-58f6-4a88-90f9-8d386200edd0.gif)

- 무료 옵션 선택 해제시 자동으로 RangeBar 값 1000으로 입력되므로 사용자가 수동으로 값을 조정하지 않아도 됨

<br>

