### PR TITLE
[BE] 코스 조회시 서버에서 필터링 하여 반환하도록 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.13.RELEASE'
     id "org.asciidoctor.jvm.convert" version "3.3.2"
     id 'java'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id 'jacoco'
 }
 
@@ -11,6 +12,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
+    querydsl.extendsFrom compileClasspath
     asciidoctorExt
     compileOnly {
         extendsFrom annotationProcessor
@@ -26,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'junit:junit:4.13.1'
     implementation 'com.auth0:java-jwt:3.19.0'
@@ -136,4 +140,18 @@ bootJar {
 
     dependsOn buildDocument
     enabled = true
+}
+
+// Querydsl
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/backend/src/main/java/com/bootme/course/controller/CourseController.java
+++ b/backend/src/main/java/com/bootme/course/controller/CourseController.java
@@ -49,9 +49,18 @@ public class CourseController {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Access-Control-Expose-Headers", "X-Total-Count");
         headers.add("X-Total-Count", String.valueOf(coursePage.getTotalElements()));
-        headers.add("Content-Range", "courses " + coursePage.getNumber() * coursePage.getSize() + "-" + (coursePage.getNumber() * coursePage.getSize() + coursePage.getNumberOfElements()) + "/" + coursePage.getTotalElements());
+        headers.add("Content-Range", getContentRange(coursePage));
 
         return ResponseEntity.ok().headers(headers).body(coursePage);
+    }
+
+
+    private String getContentRange(Page<CourseResponse> coursePage) {
+        int startRange = coursePage.getNumber() * coursePage.getSize();
+        int endRange = startRange + coursePage.getNumberOfElements();
+        long totalElements = coursePage.getTotalElements();
+
+        return String.format("courses %d-%d/%d", startRange, endRange, totalElements);
     }
 
     @PutMapping("/{id}")

--- a/backend/src/main/java/com/bootme/course/controller/CourseController.java
+++ b/backend/src/main/java/com/bootme/course/controller/CourseController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -39,10 +40,11 @@ public class CourseController {
     @GetMapping
     public ResponseEntity<Page<CourseResponse>> findAllCourses(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "12") int size
+            @RequestParam(defaultValue = "12") int size,
+            @RequestParam MultiValueMap<String, String> parameters
     ) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<CourseResponse> coursePage = courseService.findAll(pageable);
+        Page<CourseResponse> coursePage = courseService.findAll(parameters, pageable);
 
         HttpHeaders headers = new HttpHeaders();
         headers.add("Access-Control-Expose-Headers", "X-Total-Count");

--- a/backend/src/main/java/com/bootme/course/repository/CourseRepository.java
+++ b/backend/src/main/java/com/bootme/course/repository/CourseRepository.java
@@ -1,19 +1,16 @@
 package com.bootme.course.repository;
 
 import com.bootme.course.domain.Course;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository
-public interface CourseRepository extends JpaRepository<Course, Long> {
-
-    Page<Course> findAll(Pageable pageable);
+public interface CourseRepository extends JpaRepository<Course, Long>, QuerydslPredicateExecutor<Course> {
 
     @Modifying
     @Transactional

--- a/backend/src/main/java/com/bootme/course/service/CoursePredicateBuilder.java
+++ b/backend/src/main/java/com/bootme/course/service/CoursePredicateBuilder.java
@@ -1,0 +1,82 @@
+package com.bootme.course.service;
+
+import com.bootme.course.domain.QCourse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+
+import java.util.List;
+
+/**
+ * 코스 조회시 필터링을 위해 Querydsl Predicate 을 반환함
+ *
+ * <p>
+ *     1. 쿼리 파라미터로 전달받은 필터 옵션들을 확인 <br>
+ *     2. 전달 받은 필터링 옵션을 바탕으로 Predicate 객체 생성 <br>
+ *     3. 이후 데이터베이스로부터 조건에 맞는 코스 정보를 가져오는데 Predicate 객체를 사용 <br> <br>
+ * 필터 그룹 간의 상관관계 (OR, AND)
+ * <pre>
+ * |-----------------|-----------------|--------------|-----------|-----------|
+ * |                 | SuperCategories | SubCategories| Languages | Frameworks|
+ * |-----------------|-----------------|--------------|-----------|-----------|
+ * | SuperCategories | OR              | OR           | AND       | AND       |
+ * | SubCategories   | OR              | OR           | AND       | AND       |
+ * | Languages       | AND             | AND          | OR        | OR        |
+ * | Frameworks      | AND             | AND          | OR        | OR        |
+ * |-----------------|-------------- --|--------------|-----------|-----------|
+ * </pre>
+ * </p>
+ */
+@Component
+public class CoursePredicateBuilder {
+
+    public Predicate build(MultiValueMap<String, String> parameters) {
+        QCourse course = QCourse.course;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        List<String> superCategories = parameters.get("superCategory");
+        List<String> subCategories = parameters.get("subCategory");
+
+        if (superCategories != null && !superCategories.isEmpty()) {
+            BooleanBuilder superCategoryBuilder = new BooleanBuilder();
+            for (String superCategory : superCategories) {
+                superCategoryBuilder.or(course.categories.superCategory.contains(superCategory));
+            }
+            builder.and(superCategoryBuilder);
+        }
+
+        if (subCategories != null && !subCategories.isEmpty()) {
+            BooleanBuilder subCategoryBuilder = new BooleanBuilder();
+            for (String subCategory : subCategories) {
+                subCategoryBuilder.or(course.categories.subCategory.contains(subCategory));
+            }
+            builder.and(subCategoryBuilder);
+        }
+
+        List<String> languages = parameters.get("languages");
+        List<String> frameworks = parameters.get("frameworks");
+
+        if (languages != null && !languages.isEmpty()) {
+            BooleanBuilder languageBuilder = new BooleanBuilder();
+            for (String language : languages) {
+                languageBuilder.and(course.stacks.languages.contains(language));
+            }
+            builder.and(languageBuilder);
+        }
+
+        if (frameworks != null && !frameworks.isEmpty()) {
+            BooleanBuilder frameworkBuilder = new BooleanBuilder();
+            for (String framework : frameworks) {
+                frameworkBuilder.or(course.stacks.frameworks.contains(framework));
+            }
+            builder.and(frameworkBuilder);
+        }
+
+        if (builder.hasValue()) {
+            return builder.getValue();
+        } else {
+            return course.isNotNull();
+        }
+    }
+}

--- a/backend/src/main/java/com/bootme/course/service/CourseService.java
+++ b/backend/src/main/java/com/bootme/course/service/CourseService.java
@@ -6,11 +6,13 @@ import com.bootme.course.dto.CourseRequest;
 import com.bootme.course.dto.CourseResponse;
 import com.bootme.course.repository.CompanyRepository;
 import com.bootme.course.repository.CourseRepository;
+import com.querydsl.core.types.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.MultiValueMap;
 
 import static com.bootme.common.exception.ErrorType.NOT_FOUND_COMPANY;
 import static com.bootme.common.exception.ErrorType.NOT_FOUND_COURSE;
@@ -22,6 +24,7 @@ public class CourseService {
 
     private final CourseRepository courseRepository;
     private final CompanyRepository companyRepository;
+    private final CoursePredicateBuilder coursePredicateBuilder;
 
     public Long addCourse(CourseRequest courseRequest){
         String companyName = courseRequest.getCompanyName();
@@ -42,8 +45,9 @@ public class CourseService {
     }
 
     @Transactional(readOnly = true)
-    public Page<CourseResponse> findAll(Pageable pageable) {
-        Page<Course> coursePage = courseRepository.findAll(pageable);
+    public Page<CourseResponse> findAll(MultiValueMap<String, String> parameters, Pageable pageable) {
+        Predicate predicate = coursePredicateBuilder.build(parameters);
+        Page<Course> coursePage = courseRepository.findAll(predicate, pageable);
         return coursePage.map(CourseResponse::of);
     }
 


### PR DESCRIPTION
## AS-IS
- 서버에서 코스 전체 반환 후 클라이언트에서 필터링

## TO-BE
- 서버에서 코스 필터링 하여 반환
- Querydsl 사용하여 필터링 구현

### 필터링 그룹간 관계
  | SuperCategories | SubCategories | Languages | Frameworks
-- | -- | -- | -- | --
SuperCategories | OR | OR | AND | AND
SubCategories | OR | OR | AND | AND
Languages | AND | AND | OR | OR
Frameworks | AND | AND | OR | OR

<br>


