### PR TITLE
[BE] 시크릿 정보 서버에서 받아서 클라이언트로 전송하도록 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.amazonaws:aws-java-sdk-s3'
     implementation 'org.springframework.cloud:spring-cloud-aws-core:2.2.6.RELEASE'
+    implementation 'com.amazonaws.secretsmanager:aws-secretsmanager-caching-java:1.0.2'
     implementation 'org.apache.tika:tika-core:1.26'
     implementation 'com.querydsl:querydsl-jpa:5.0.0'
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0'

--- a/backend/src/main/java/com/bootme/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bootme/auth/controller/AuthController.java
@@ -20,7 +20,7 @@ public class AuthController {
 
     public AuthController(AuthService authService,
                           TokenProvider tokenProvider,
-                          @Value("${domain}") String domain) {
+                          @Value("${domain}") String domain ) {
         this.authService = authService;
         this.tokenProvider = tokenProvider;
         this.domain = domain;

--- a/backend/src/main/java/com/bootme/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bootme/auth/controller/AuthController.java
@@ -1,10 +1,12 @@
 package com.bootme.auth.controller;
 
+import com.bootme.auth.dto.SecretResponse;
 import com.bootme.auth.service.AuthService;
 import com.bootme.auth.token.TokenProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,4 +46,11 @@ public class AuthController {
         response.addHeader(HttpHeaders.SET_COOKIE, "refreshToken=; Max-Age=0; Domain=" + domain + ";");
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/secrets")
+    public ResponseEntity<SecretResponse> getSecrets() {
+        SecretResponse secretResponse = authService.getAwsSecrets();
+        return ResponseEntity.ok(secretResponse);
+    }
+
 }

--- a/backend/src/main/java/com/bootme/auth/dto/SecretResponse.java
+++ b/backend/src/main/java/com/bootme/auth/dto/SecretResponse.java
@@ -1,0 +1,66 @@
+package com.bootme.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class SecretResponse {
+
+    private String apiUrl;
+    private String googleClientId;
+    private String naverClientId;
+    private String naverClientSecret;
+    private String naverIssuer;
+    private String naverAudience;
+    private String naverSigningKey;
+    private String kakaoRestApiKey;
+    private String kakaoClientSecret;
+    private String webhookIssuer;
+    private String webhookAudience;
+    private String webhookSigningKey;
+    private String kakaoJavascriptKey;
+
+    public SecretResponse() {
+    }
+
+    @Builder
+    public SecretResponse(String apiUrl, String googleClientId, String naverClientId, String naverClientSecret,
+                          String naverIssuer, String naverAudience, String naverSigningKey, String kakaoRestApiKey,
+                          String kakaoClientSecret, String webhookIssuer, String webhookAudience, String webhookSigningKey,
+                          String kakaoJavascriptKey) {
+        this.apiUrl = apiUrl;
+        this.googleClientId = googleClientId;
+        this.naverClientId = naverClientId;
+        this.naverClientSecret = naverClientSecret;
+        this.naverIssuer = naverIssuer;
+        this.naverAudience = naverAudience;
+        this.naverSigningKey = naverSigningKey;
+        this.kakaoRestApiKey = kakaoRestApiKey;
+        this.kakaoClientSecret = kakaoClientSecret;
+        this.webhookIssuer = webhookIssuer;
+        this.webhookAudience = webhookAudience;
+        this.webhookSigningKey = webhookSigningKey;
+        this.kakaoJavascriptKey = kakaoJavascriptKey;
+    }
+
+    public static SecretResponse of(Map<String, String> secrets) {
+        return SecretResponse.builder()
+                .apiUrl(secrets.get("api-url"))
+                .googleClientId(secrets.get("google-client-id"))
+                .naverClientId(secrets.get("naver-client-id"))
+                .naverClientSecret(secrets.get("naver-client-secret"))
+                .naverIssuer(secrets.get("naver-issuer"))
+                .naverAudience(secrets.get("naver-audience"))
+                .naverSigningKey(secrets.get("naver-signing-key"))
+                .kakaoRestApiKey(secrets.get("kakao-rest-api-key"))
+                .kakaoClientSecret(secrets.get("kakao-client-secret"))
+                .webhookIssuer(secrets.get("webhook-issuer"))
+                .webhookAudience(secrets.get("webhook-audience"))
+                .webhookSigningKey(secrets.get("webhook-signing-key"))
+                .kakaoJavascriptKey(secrets.get("kakao-javascript-key"))
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/bootme/common/exception/BadRequestException.java
+++ b/backend/src/main/java/com/bootme/common/exception/BadRequestException.java
@@ -5,15 +5,15 @@ import lombok.Getter;
 @Getter
 public abstract class BadRequestException extends BusinessException {
 
-    public BadRequestException(ErrorType errorType){
+    protected BadRequestException(ErrorType errorType){
         super(errorType);
     }
 
-    public BadRequestException(ErrorType errorType, String invalidInput){
+    protected BadRequestException(ErrorType errorType, String invalidInput){
         super(errorType, invalidInput);
     }
 
-    public BadRequestException(ErrorType errorType, String invalidInput, Throwable cause){
+    protected BadRequestException(ErrorType errorType, String invalidInput, Throwable cause){
         super(errorType, invalidInput, cause);
     }
 

--- a/backend/src/main/java/com/bootme/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/bootme/common/exception/ErrorType.java
@@ -56,8 +56,11 @@ public enum ErrorType {
     INVALID_VOTE_TYPE       (5013, "유효하지 않은 voteType 입니다. 유효한 값: upvote || downvote"),
     INVALID_VOTABLE_TYPE    (5014, "유효하지 않은 votableType 입니다."),
 
+    // System errors
+    JSON_PROCESSING_FAIL    (6001, "JSON 처리에 실패했습니다."),
+
     // AWS
-    S3_UPLOAD_FAIL          (6001, "이미지 파일을 S3 업로드 실패했습니다."),
+    S3_UPLOAD_FAIL          (7001, "이미지 파일을 S3 업로드 실패했습니다."),
 
     // Internal server errors
     RUNTIME_EXCEPTION       (9001, "서버에 알 수 없는 문제가 발생했습니다.");

--- a/backend/src/main/java/com/bootme/common/exception/ForbiddenException.java
+++ b/backend/src/main/java/com/bootme/common/exception/ForbiddenException.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 @Getter
 public abstract class ForbiddenException extends BusinessException {
 
-    public ForbiddenException(ErrorType errorType){
+    protected ForbiddenException(ErrorType errorType){
         super(errorType);
     }
 
-    public ForbiddenException(ErrorType errorType, String invalidInput){
+    protected ForbiddenException(ErrorType errorType, String invalidInput){
         super(errorType, invalidInput);
     }
 

--- a/backend/src/main/java/com/bootme/common/exception/SerializationException.java
+++ b/backend/src/main/java/com/bootme/common/exception/SerializationException.java
@@ -1,0 +1,17 @@
+package com.bootme.common.exception;
+
+public class SerializationException extends SystemException {
+
+    public SerializationException(ErrorType errorType) {
+        super(errorType);
+    }
+
+    public SerializationException(ErrorType errorType, String invalidInput) {
+        super(errorType, invalidInput);
+    }
+
+    public SerializationException(ErrorType errorType, String invalidInput, Throwable cause) {
+        super(errorType, invalidInput, cause);
+    }
+
+}

--- a/backend/src/main/java/com/bootme/common/exception/SystemException.java
+++ b/backend/src/main/java/com/bootme/common/exception/SystemException.java
@@ -3,21 +3,21 @@ package com.bootme.common.exception;
 import lombok.Getter;
 
 @Getter
-public abstract class BusinessException extends RuntimeException {
+public abstract class SystemException extends RuntimeException {
 
     private final ErrorType errorType;
 
-    protected BusinessException(ErrorType errorType) {
+    protected SystemException(ErrorType errorType) {
         super(errorType.getMessage());
         this.errorType = errorType;
     }
 
-    protected BusinessException(ErrorType errorType, String invalidInput) {
+    protected SystemException(ErrorType errorType, String invalidInput) {
         super(errorType.getMessage(invalidInput));
         this.errorType = errorType;
     }
 
-    protected BusinessException(ErrorType errorType, String invalidInput, Throwable cause) {
+    protected SystemException(ErrorType errorType, String invalidInput, Throwable cause) {
         super(errorType.getMessage(invalidInput), cause);
         this.errorType = errorType;
     }

--- a/backend/src/main/java/com/bootme/common/exception/TokenParseException.java
+++ b/backend/src/main/java/com/bootme/common/exception/TokenParseException.java
@@ -1,7 +1,4 @@
-package com.bootme.auth.exception;
-
-import com.bootme.common.exception.BadRequestException;
-import com.bootme.common.exception.ErrorType;
+package com.bootme.common.exception;
 
 public class TokenParseException extends BadRequestException {
 

--- a/backend/src/main/java/com/bootme/common/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/bootme/common/exception/UnauthorizedException.java
@@ -5,15 +5,15 @@ import lombok.Getter;
 @Getter
 public abstract class UnauthorizedException extends BusinessException {
 
-    public UnauthorizedException(ErrorType errorType) {
+    protected UnauthorizedException(ErrorType errorType) {
         super(errorType);
     }
 
-    public UnauthorizedException(ErrorType errorType, String invalidInput) {
+    protected UnauthorizedException(ErrorType errorType, String invalidInput) {
         super(errorType, invalidInput);
     }
 
-    public UnauthorizedException(ErrorType errorType, String invalidInput, Throwable e) {
+    protected UnauthorizedException(ErrorType errorType, String invalidInput, Throwable e) {
         super(errorType, invalidInput, e);
     }
 

--- a/backend/src/main/java/com/bootme/config/AWSSecretsManagerConfig.java
+++ b/backend/src/main/java/com/bootme/config/AWSSecretsManagerConfig.java
@@ -1,0 +1,27 @@
+package com.bootme.config;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AWSSecretsManagerConfig {
+
+    @Bean
+    public AWSSecretsManager awsSecretsManager() {
+        return AWSSecretsManagerClientBuilder.standard()
+                .withRegion(Regions.AP_NORTHEAST_2)
+                .withCredentials(new DefaultAWSCredentialsProviderChain())
+                .build();
+    }
+
+    @Bean
+    public SecretCache secretCache(AWSSecretsManager awsSecretsManager) {
+        return new SecretCache(awsSecretsManager);
+    }
+
+}

--- a/backend/src/test/java/com/bootme/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/bootme/auth/controller/AuthControllerTest.java
@@ -1,6 +1,6 @@
 package com.bootme.auth.controller;
 
-import com.bootme.auth.exception.TokenParseException;
+import com.bootme.common.exception.TokenParseException;
 import com.bootme.common.exception.AuthenticationException;
 import com.bootme.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## AS-IS
- AWS Secrets Manager에 저장된 시크릿 정보를 클라이언트에서 바로 요청 & 수신하여 사용
- 클라이언트의 시크릿 정보 요청이 dev tool에 그대로 노출됨 (시크릿 응답값 포함)

## TO-BE
- 서버에서 AWS Secrets Manager 시크릿 받아와서 클라이언트로 전달
- 시크릿 값 노출되지 않음

