### PR TITLE
[BE] 시크릿 요청 보안 강화

### DIFF
--- a/backend/src/main/java/com/bootme/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bootme/auth/controller/AuthController.java
@@ -2,7 +2,8 @@ package com.bootme.auth.controller;
 
 import com.bootme.auth.dto.SecretResponse;
 import com.bootme.auth.service.AuthService;
-import com.bootme.auth.token.TokenProvider;
+import com.bootme.auth.utils.IPFiltering;
+import com.bootme.auth.utils.TokenProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +23,7 @@ public class AuthController {
 
     public AuthController(AuthService authService,
                           TokenProvider tokenProvider,
-                          @Value("${domain}") String domain ) {
+                          @Value("${domain}") String domain) {
         this.authService = authService;
         this.tokenProvider = tokenProvider;
         this.domain = domain;

--- a/backend/src/main/java/com/bootme/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bootme/auth/controller/AuthController.java
@@ -48,6 +48,7 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
+    @IPFiltering
     @GetMapping("/secrets")
     public ResponseEntity<SecretResponse> getSecrets() {
         SecretResponse secretResponse = authService.getAwsSecrets();

--- a/backend/src/main/java/com/bootme/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bootme/auth/controller/AuthController.java
@@ -50,7 +50,9 @@ public class AuthController {
 
     @IPFiltering
     @GetMapping("/secrets")
-    public ResponseEntity<SecretResponse> getSecrets() {
+    public ResponseEntity<SecretResponse> getSecrets(@RequestHeader(name = "Bootme_Secret") String secret,
+                                                     @RequestHeader(value = "Origin", required = false) String origin) {
+        authService.verifySecretRequest(secret, origin);
         SecretResponse secretResponse = authService.getAwsSecrets();
         return ResponseEntity.ok(secretResponse);
     }

--- a/backend/src/main/java/com/bootme/auth/service/AuthService.java
+++ b/backend/src/main/java/com/bootme/auth/service/AuthService.java
@@ -10,10 +10,8 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.bootme.auth.dto.AuthInfo;
 import com.bootme.auth.dto.JwtVo;
 import com.bootme.auth.dto.SecretResponse;
-import com.bootme.auth.token.JwkProviderSingleton;
-import com.bootme.common.exception.AuthenticationException;
-import com.bootme.common.exception.SerializationException;
-import com.bootme.common.exception.TokenParseException;
+import com.bootme.auth.utils.JwkProviderSingleton;
+import com.bootme.common.exception.*;
 import com.bootme.member.domain.Member;
 import com.bootme.member.repository.MemberRepository;
 import com.bootme.member.service.MemberService;
@@ -31,12 +29,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
-import java.util.Base64;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.bootme.auth.token.GoogleIdTokenVerifierSingleton.verifyGoogleIdToken;
+import static com.bootme.auth.utils.GoogleIdTokenVerifierSingleton.verifyGoogleIdToken;
 import static com.bootme.common.exception.ErrorType.*;
 
 

--- a/backend/src/main/java/com/bootme/auth/utils/AuthenticationArgumentResolver.java
+++ b/backend/src/main/java/com/bootme/auth/utils/AuthenticationArgumentResolver.java
@@ -1,4 +1,4 @@
-package com.bootme.auth.token;
+package com.bootme.auth.utils;
 
 import com.bootme.auth.dto.AuthInfo;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/bootme/auth/utils/GoogleIdTokenVerifierSingleton.java
+++ b/backend/src/main/java/com/bootme/auth/utils/GoogleIdTokenVerifierSingleton.java
@@ -1,4 +1,4 @@
-package com.bootme.auth.token;
+package com.bootme.auth.utils;
 
 import com.bootme.common.exception.AuthenticationException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;

--- a/backend/src/main/java/com/bootme/auth/utils/IPFiltering.java
+++ b/backend/src/main/java/com/bootme/auth/utils/IPFiltering.java
@@ -1,0 +1,11 @@
+package com.bootme.auth.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IPFiltering {
+}

--- a/backend/src/main/java/com/bootme/auth/utils/JwkProviderSingleton.java
+++ b/backend/src/main/java/com/bootme/auth/utils/JwkProviderSingleton.java
@@ -1,4 +1,4 @@
-package com.bootme.auth.token;
+package com.bootme.auth.utils;
 
 import com.auth0.jwk.JwkProvider;
 import com.auth0.jwk.JwkProviderBuilder;

--- a/backend/src/main/java/com/bootme/auth/utils/Login.java
+++ b/backend/src/main/java/com/bootme/auth/utils/Login.java
@@ -1,4 +1,4 @@
-package com.bootme.auth.token;
+package com.bootme.auth.utils;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/backend/src/main/java/com/bootme/auth/utils/TokenProvider.java
+++ b/backend/src/main/java/com/bootme/auth/utils/TokenProvider.java
@@ -1,4 +1,4 @@
-package com.bootme.auth.token;
+package com.bootme.auth.utils;
 
 import com.bootme.auth.dto.AuthInfo;
 import com.bootme.member.domain.Member;

--- a/backend/src/main/java/com/bootme/common/exception/AccessDeniedException.java
+++ b/backend/src/main/java/com/bootme/common/exception/AccessDeniedException.java
@@ -1,6 +1,7 @@
 package com.bootme.common.exception;
 
 public class AccessDeniedException extends ForbiddenException {
+
     public AccessDeniedException(ErrorType errorType) {
         super(errorType);
     }

--- a/backend/src/main/java/com/bootme/common/interceptor/IPFilter.java
+++ b/backend/src/main/java/com/bootme/common/interceptor/IPFilter.java
@@ -1,0 +1,46 @@
+package com.bootme.common.interceptor;
+
+import com.bootme.auth.utils.IPFiltering;
+import com.bootme.common.exception.AccessDeniedException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.bootme.common.exception.ErrorType.FORBIDDEN_REQUEST;
+
+@Component
+public class IPFilter implements HandlerInterceptor {
+
+
+    private final List<String> allowedIps;
+
+    public IPFilter(@Value("${allowed-ips}") String allowedOriginsString) {
+        this.allowedIps = Arrays.asList(allowedOriginsString.split(","));
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod method = (HandlerMethod) handler;
+
+            IPFiltering ipFiltering = method.getMethodAnnotation(IPFiltering.class);
+
+            if (ipFiltering != null) {
+                String requestIP = request.getRemoteAddr();
+                if (allowedIps.contains(requestIP)) {
+                    return true;
+                } else {
+                    throw new AccessDeniedException(FORBIDDEN_REQUEST, requestIP);
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/backend/src/main/java/com/bootme/common/interceptor/TokenValidationInterceptor.java
+++ b/backend/src/main/java/com/bootme/common/interceptor/TokenValidationInterceptor.java
@@ -1,7 +1,7 @@
 package com.bootme.common.interceptor;
 
 import com.bootme.auth.service.AuthService;
-import com.bootme.auth.token.TokenProvider;
+import com.bootme.auth.utils.TokenProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;

--- a/backend/src/main/java/com/bootme/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/bootme/config/WebMvcConfig.java
@@ -1,6 +1,6 @@
 package com.bootme.config;
 
-import com.bootme.auth.token.AuthenticationArgumentResolver;
+import com.bootme.auth.utils.AuthenticationArgumentResolver;
 import com.bootme.common.interceptor.TokenValidationInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -22,6 +22,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                         AuthenticationArgumentResolver authenticationArgumentResolver) {
         this.tokenValidationInterceptor = tokenValidationInterceptor;
         this.authenticationArgumentResolver = authenticationArgumentResolver;
+        this.allowedOrigins = allowedOrigins.split(",");
     }
 
     @Override

--- a/backend/src/main/java/com/bootme/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/bootme/config/WebMvcConfig.java
@@ -20,10 +20,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
     private final TokenValidationInterceptor tokenValidationInterceptor;
     private final IPFilter ipFilter;
     private final AuthenticationArgumentResolver authenticationArgumentResolver;
+    private final String[] allowedOrigins;
 
     public WebMvcConfig(TokenValidationInterceptor tokenValidationInterceptor,
                         IPFilter ipFilter,
-                        AuthenticationArgumentResolver authenticationArgumentResolver,) {
+                        AuthenticationArgumentResolver authenticationArgumentResolver,
+                        @Value("${allowed-origins}") String allowedOrigins) {
         this.tokenValidationInterceptor = tokenValidationInterceptor;
         this.ipFilter = ipFilter;
         this.authenticationArgumentResolver = authenticationArgumentResolver;
@@ -33,10 +35,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000",
-                                "http://localhost:3001",
-                                "https://bootme.co.kr",
-                                "https://www.bootme.co.kr")
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/backend/src/main/java/com/bootme/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/bootme/config/WebMvcConfig.java
@@ -2,6 +2,8 @@ package com.bootme.config;
 
 import com.bootme.auth.utils.AuthenticationArgumentResolver;
 import com.bootme.common.interceptor.TokenValidationInterceptor;
+import com.bootme.common.interceptor.IPFilter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -16,11 +18,14 @@ public class WebMvcConfig implements WebMvcConfigurer {
     private static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,DELETE,TRACE,OPTIONS,PATCH,PUT";
 
     private final TokenValidationInterceptor tokenValidationInterceptor;
+    private final IPFilter ipFilter;
     private final AuthenticationArgumentResolver authenticationArgumentResolver;
 
     public WebMvcConfig(TokenValidationInterceptor tokenValidationInterceptor,
-                        AuthenticationArgumentResolver authenticationArgumentResolver) {
+                        IPFilter ipFilter,
+                        AuthenticationArgumentResolver authenticationArgumentResolver,) {
         this.tokenValidationInterceptor = tokenValidationInterceptor;
+        this.ipFilter = ipFilter;
         this.authenticationArgumentResolver = authenticationArgumentResolver;
         this.allowedOrigins = allowedOrigins.split(",");
     }
@@ -45,6 +50,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/login")
                 .excludePathPatterns("/logout")
                 .excludePathPatterns("/docs/**");
+        registry.addInterceptor(ipFilter);
     }
 
     @Override

--- a/backend/src/main/java/com/bootme/image/controller/ImageController.java
+++ b/backend/src/main/java/com/bootme/image/controller/ImageController.java
@@ -1,7 +1,7 @@
 package com.bootme.image.controller;
 
 import com.bootme.auth.dto.AuthInfo;
-import com.bootme.auth.token.Login;
+import com.bootme.auth.utils.Login;
 import com.bootme.image.service.ImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/backend/src/main/java/com/bootme/post/controller/CommentController.java
+++ b/backend/src/main/java/com/bootme/post/controller/CommentController.java
@@ -1,7 +1,7 @@
 package com.bootme.post.controller;
 
 import com.bootme.auth.dto.AuthInfo;
-import com.bootme.auth.token.Login;
+import com.bootme.auth.utils.Login;
 import com.bootme.post.dto.CommentRequest;
 import com.bootme.post.dto.CommentResponse;
 import com.bootme.post.service.CommentService;

--- a/backend/src/main/java/com/bootme/post/controller/PostController.java
+++ b/backend/src/main/java/com/bootme/post/controller/PostController.java
@@ -1,7 +1,7 @@
 package com.bootme.post.controller;
 
 import com.bootme.auth.dto.AuthInfo;
-import com.bootme.auth.token.Login;
+import com.bootme.auth.utils.Login;
 import com.bootme.post.dto.CommentResponse;
 import com.bootme.post.dto.PostDetailResponse;
 import com.bootme.post.dto.PostRequest;

--- a/backend/src/main/java/com/bootme/post/controller/VoteController.java
+++ b/backend/src/main/java/com/bootme/post/controller/VoteController.java
@@ -1,7 +1,7 @@
 package com.bootme.post.controller;
 
 import com.bootme.auth.dto.AuthInfo;
-import com.bootme.auth.token.Login;
+import com.bootme.auth.utils.Login;
 import com.bootme.post.dto.VotableResponse;
 import com.bootme.post.dto.VoteRequest;
 import com.bootme.post.service.VoteService;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: prod
+    active: dev
   servlet:
     multipart:
       max-file-size: 10MB
@@ -9,3 +9,6 @@ spring:
 jasypt:
   encryptor:
     password: encryptKey
+
+allowed-origins: http://localhost:3000,http://localhost:3001,https://bootme.co.kr,https://www.bootme.co.kr
+allowed-ips: ENC(MwT3n0qoybLgG3wfWhq1/C4qT0zRRaY5g31Fg7ltpqulNdnF8ttUKA==)

--- a/backend/src/test/java/com/bootme/auth/utils/TokenProviderTest.java
+++ b/backend/src/test/java/com/bootme/auth/utils/TokenProviderTest.java
@@ -1,4 +1,4 @@
-package com.bootme.auth.token;
+package com.bootme.auth.utils;
 
 import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/src/test/java/com/bootme/util/ControllerTest.java
+++ b/backend/src/test/java/com/bootme/util/ControllerTest.java
@@ -1,7 +1,7 @@
 package com.bootme.util;
 
 import com.bootme.auth.service.AuthService;
-import com.bootme.auth.token.TokenProvider;
+import com.bootme.auth.utils.TokenProvider;
 import com.bootme.common.interceptor.TokenValidationInterceptor;
 import com.bootme.course.service.CompanyService;
 import com.bootme.course.service.CourseService;

--- a/backend/src/test/java/com/bootme/util/ServiceTest.java
+++ b/backend/src/test/java/com/bootme/util/ServiceTest.java
@@ -1,7 +1,7 @@
 package com.bootme.util;
 
 import com.bootme.auth.service.AuthService;
-import com.bootme.auth.token.TokenProvider;
+import com.bootme.auth.utils.TokenProvider;
 import com.bootme.common.interceptor.TokenValidationInterceptor;
 import com.bootme.course.service.CompanyService;
 import com.bootme.course.service.CourseService;

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,4 +1,6 @@
 domain: localhost
+allowed-origins: http://localhost:3000,http://localhost:3001,https://bootme.co.kr,https://www.bootme.co.kr
+allowed-ips: ENC(MwT3n0qoybLgG3wfWhq1/C4qT0zRRaY5g31Fg7ltpqulNdnF8ttUKA==)
 
 jasypt:
   encryptor:


### PR DESCRIPTION
## 시크릿 요청에 추가된 검증
- IP 주소 검증 추가
  - 지정된 IP 주소만 시크릿 요청 허용됨
  - `@IPFiltering` 커스텀 어노테이션 사용하여 구현
- 토큰, origin 검증 추가
  - JWT 검증 및 origin 헤더 검증 추가됨

![image](https://github.com/Jinwook94/bootme/assets/44575214/3811edac-6723-4710-8bb7-d080058e57bc)

