### PR TITLE
[BE] 프로필 조회, 수정 API 구현

### DIFF
--- a/backend/src/main/java/com/bootme/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/bootme/common/exception/ErrorType.java
@@ -21,6 +21,7 @@ public enum ErrorType {
     NAVER_LOGIN_FAIL        (1011, "네이버 로그인에 실패했습니다."),
     NOT_WRITER              (1012, "게시글 작성자가 아닙니다."),
     INVALID_EMAIL_NULL      (1013, "이메일은 필수 입력값입니다."),
+    MEMBER_ID_MISMATCH      (1014, "엑세스 토큰의 id와 요청 경로의 id가 다릅니다."),
 
     // Authorization
     FORBIDDEN_REQUEST       (2001, "권한이 없습니다."),

--- a/backend/src/main/java/com/bootme/image/controller/ImageController.java
+++ b/backend/src/main/java/com/bootme/image/controller/ImageController.java
@@ -17,8 +17,8 @@ public class ImageController {
 
     @PostMapping
     public ResponseEntity<String> upload(@Login AuthInfo authInfo,
-                                                @RequestParam String imageType,
-                                                @RequestPart("image") MultipartFile imageFile) {
+                                         @RequestParam String imageType,
+                                         @RequestPart("image") MultipartFile imageFile) {
         String imageUrl = imageService.upload(authInfo, imageType, imageFile);
         return ResponseEntity.ok(imageUrl);
     }

--- a/backend/src/main/java/com/bootme/image/service/ImageService.java
+++ b/backend/src/main/java/com/bootme/image/service/ImageService.java
@@ -29,6 +29,7 @@ public class ImageService {
     private final AuthService authService;
     private final AmazonS3 amazonS3Client;
 
+    private static final String PROFILE = "profile";
     private static final String COURSE_DETAIL = "courseDetail";
     private static final String POST = "post";
     private static final String POST_COMMENT = "postComment";
@@ -58,6 +59,9 @@ public class ImageService {
     private String getFormattedFileName(String imageType, Long memberId, File image) {
         String uploadPath;
         switch (imageType) {
+            case PROFILE:
+                uploadPath = String.format("profile/%d/", memberId);
+                break;
             case COURSE_DETAIL:
                 uploadPath = String.format("course-detail/%d/", memberId);
                 break;

--- a/backend/src/main/java/com/bootme/member/controller/MemberController.java
+++ b/backend/src/main/java/com/bootme/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.bootme.auth.dto.AuthInfo;
 import com.bootme.auth.util.Login;
 import com.bootme.course.dto.CourseResponse;
 import com.bootme.member.dto.ProfileResponse;
+import com.bootme.member.dto.UpdateImageRequest;
 import com.bootme.member.dto.UpdateProfileRequest;
 import com.bootme.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,14 @@ public class MemberController {
                                               @PathVariable Long memberId,
                                               @RequestBody UpdateProfileRequest request) {
         memberService.modifyProfile(authInfo, memberId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{memberId}/profile_image")
+    public ResponseEntity<Void> modifyProfileImage(@Login AuthInfo authInfo,
+                                                   @PathVariable Long memberId,
+                                                   @RequestBody UpdateImageRequest request) {
+        memberService.modifyProfileImage(authInfo, memberId, request);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/com/bootme/member/controller/MemberController.java
+++ b/backend/src/main/java/com/bootme/member/controller/MemberController.java
@@ -3,8 +3,7 @@ package com.bootme.member.controller;
 import com.bootme.auth.dto.AuthInfo;
 import com.bootme.auth.util.Login;
 import com.bootme.course.dto.CourseResponse;
-import com.bootme.member.domain.Member;
-import com.bootme.member.dto.MemberResponse;
+import com.bootme.member.dto.ProfileResponse;
 import com.bootme.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,10 +22,9 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public ResponseEntity<MemberResponse> getMember(@Login AuthInfo authInfo) {
-        Member member = memberService.getMemberById(authInfo.getMemberId());
-        MemberResponse of = MemberResponse.of(member);
-        return ResponseEntity.ok(of);
+    public ResponseEntity<ProfileResponse> getProfile(@Login AuthInfo authInfo) {
+        ProfileResponse response = memberService.findMemberProfile(authInfo);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/nickname/{nickname}/exists")

--- a/backend/src/main/java/com/bootme/member/controller/MemberController.java
+++ b/backend/src/main/java/com/bootme/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.bootme.auth.dto.AuthInfo;
 import com.bootme.auth.util.Login;
 import com.bootme.course.dto.CourseResponse;
 import com.bootme.member.dto.ProfileResponse;
+import com.bootme.member.dto.UpdateProfileRequest;
 import com.bootme.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,6 +26,14 @@ public class MemberController {
     public ResponseEntity<ProfileResponse> getProfile(@Login AuthInfo authInfo) {
         ProfileResponse response = memberService.findMemberProfile(authInfo);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{memberId}")
+    public ResponseEntity<Void> modifyProfile(@Login AuthInfo authInfo,
+                                              @PathVariable Long memberId,
+                                              @RequestBody UpdateProfileRequest request) {
+        memberService.modifyProfile(authInfo, memberId, request);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/nickname/{nickname}/exists")

--- a/backend/src/main/java/com/bootme/member/domain/Member.java
+++ b/backend/src/main/java/com/bootme/member/domain/Member.java
@@ -3,7 +3,9 @@ package com.bootme.member.domain;
 import com.bootme.auth.dto.UserInfo;
 import com.bootme.common.domain.BaseEntity;
 import com.bootme.common.exception.ArgumentNotValidException;
+import com.bootme.common.exception.AuthenticationException;
 import com.bootme.common.exception.ErrorType;
+import com.bootme.member.dto.UpdateImageRequest;
 import com.bootme.notification.domain.Notification;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,8 +13,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+
+import static com.bootme.common.exception.ErrorType.MEMBER_ID_MISMATCH;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -107,6 +110,33 @@ public class Member extends BaseEntity {
                 .roleType(RoleType.USER)
                 .visitsCount(1L)
                 .build();
+    }
+
+    public void modifyEmail(String email) {
+        this.email = email;
+    }
+
+    public void modifyProfileImage(UpdateImageRequest request) {
+        this.profileImage = request.getProfileImage();
+    }
+
+    public void modifyJob(String job) {
+        this.job = job;
+    }
+
+    public void modifyNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void modifyStacks(List<MemberStack> newStacks) {
+        this.memberStacks.clear();
+        this.memberStacks.addAll(newStacks);
+    }
+
+    public void validateIdMatchesToken(Long authInfoId, Long receivedId) {
+        if (!Objects.equals(authInfoId, receivedId)) {
+            throw new AuthenticationException(MEMBER_ID_MISMATCH, String.valueOf(receivedId));
+        }
     }
 
 }

--- a/backend/src/main/java/com/bootme/member/domain/MemberStack.java
+++ b/backend/src/main/java/com/bootme/member/domain/MemberStack.java
@@ -34,4 +34,11 @@ public class MemberStack extends BaseEntity {
         this.stack = stack;
     }
 
+    public static MemberStack of(Member member, Stack stack) {
+        return MemberStack.builder()
+                .member(member)
+                .stack(stack)
+                .build();
+    }
+
 }

--- a/backend/src/main/java/com/bootme/member/dto/ProfileResponse.java
+++ b/backend/src/main/java/com/bootme/member/dto/ProfileResponse.java
@@ -5,26 +5,29 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class MemberResponse {
+public class ProfileResponse {
     private String profileImage;
     private String email;
     private String nickname;
     private String job;
+    private String[] stacks;
 
     @Builder
-    public MemberResponse(String profileImage, String email, String nickname, String job) {
+    public ProfileResponse(String profileImage, String email, String nickname, String job, String[] stacks) {
         this.profileImage = profileImage;
         this.email = email;
         this.nickname = nickname;
         this.job = job;
+        this.stacks = stacks;
     }
 
-    public static MemberResponse of(Member member) {
-        return MemberResponse.builder()
+    public static ProfileResponse of(Member member, String[] stacks) {
+        return ProfileResponse.builder()
                 .profileImage(member.getProfileImage())
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .job(member.getJob())
+                .stacks(stacks)
                 .build();
     }
 

--- a/backend/src/main/java/com/bootme/member/dto/UpdateImageRequest.java
+++ b/backend/src/main/java/com/bootme/member/dto/UpdateImageRequest.java
@@ -1,0 +1,17 @@
+package com.bootme.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateImageRequest {
+
+    private String profileImage;
+
+    public UpdateImageRequest() {
+    }
+
+    public UpdateImageRequest(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
+}

--- a/backend/src/main/java/com/bootme/member/dto/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/bootme/member/dto/UpdateProfileRequest.java
@@ -1,0 +1,27 @@
+package com.bootme.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UpdateProfileRequest {
+
+    private String email;
+    private String nickname;
+    private String job;
+    private List<String> stacks;
+
+    public UpdateProfileRequest() {
+    }
+
+    @Builder
+    public UpdateProfileRequest(String email, String nickname, String job, List<String> stacks) {
+        this.email = email;
+        this.nickname = nickname;
+        this.job = job;
+        this.stacks = stacks;
+    }
+
+}

--- a/backend/src/main/java/com/bootme/member/repository/MemberStackRepository.java
+++ b/backend/src/main/java/com/bootme/member/repository/MemberStackRepository.java
@@ -1,0 +1,11 @@
+package com.bootme.member.repository;
+
+import com.bootme.member.domain.MemberStack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemberStackRepository extends JpaRepository<MemberStack, Long> {
+    List<MemberStack> findByMember_Id(Long memberId);
+}
+

--- a/backend/src/main/java/com/bootme/member/service/MemberService.java
+++ b/backend/src/main/java/com/bootme/member/service/MemberService.java
@@ -13,6 +13,7 @@ import com.bootme.member.domain.BookmarkCourse;
 import com.bootme.member.domain.Member;
 import com.bootme.member.domain.MemberStack;
 import com.bootme.member.dto.ProfileResponse;
+import com.bootme.member.dto.UpdateImageRequest;
 import com.bootme.member.dto.UpdateProfileRequest;
 import com.bootme.member.repository.BookmarkCourseRepository;
 import com.bootme.member.repository.MemberRepository;
@@ -87,6 +88,14 @@ public class MemberService {
                 .filter(stackName -> member.getMemberStacks().stream().noneMatch(stack -> stack.getStack().getName().equals(stackName)))
                 .map(stackName -> MemberStack.of(member, stackService.getStackByName(stackName)))
                 .collect(Collectors.toList());
+    }
+
+    public void modifyProfileImage(AuthInfo authinfo, Long memberId, UpdateImageRequest request) {
+        authService.validateLogin(authinfo);
+        Member member = getMemberById(memberId);
+        member.validateIdMatchesToken(authinfo.getMemberId(), memberId);
+
+        member.modifyProfileImage(request);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/bootme/stack/service/StackService.java
+++ b/backend/src/main/java/com/bootme/stack/service/StackService.java
@@ -1,6 +1,7 @@
 package com.bootme.stack.service;
 
 import com.bootme.common.exception.ConflictException;
+import com.bootme.common.exception.ResourceNotFoundException;
 import com.bootme.stack.domain.Stack;
 import com.bootme.stack.dto.StackRequest;
 import com.bootme.stack.dto.StackResponse;
@@ -13,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.bootme.common.exception.ErrorType.ALREADY_SAVED_STACK;
+import static com.bootme.common.exception.ErrorType.NOT_FOUND_STACK;
 
 @Service
 @Transactional
@@ -43,6 +45,11 @@ public class StackService {
         if(isExist){
             throw new ConflictException(ALREADY_SAVED_STACK, name);
         }
+    }
+
+    public Stack getStackByName(String name) {
+        return stackRepository.findByName(name)
+                .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_STACK, name));
     }
 
 }

--- a/backend/src/test/java/com/bootme/rest.http
+++ b/backend/src/test/java/com/bootme/rest.http
@@ -1,6 +1,14 @@
+### 카카오 토큰 정보
+GET https://kapi.kakao.com/v1/user/access_token_info HTTP/1.1
+Authorization: Bearer token
+
+### 카카오 로그아웃
+GET https://kapi.kakao.com/v1/user/logout
+Authorization: Bearer token
+
 ### 시크릿
 GET localhost:8080/secrets HTTP/1.1
-Bootme_secret: Bearer bootme-client-generated-jwt
+Bootme_secret: Bearer token
 Origin: https://bootme.co.kr
 Accept: application/json
 Host: api.bootMe.app
@@ -17,7 +25,6 @@ Content-Type: application/json
 Cookie: accessToken=
 
 {
-  "memberId" : "1",
   "topic" : "자유",
   "title" : "안녕하세요",
   "content" : "반갑습니다"
@@ -39,18 +46,82 @@ POST localhost:8080/stacks HTTP/1.1
 Content-Type: application/json
 
 [
-  {"name": "JavaScript", "type": "language"},
-  {"name": "TypeScript", "type": "language"},
-  {"name": "Java", "type": "language"},
-  {"name": "Python", "type": "language"},
-  {"name": "Swift", "type": "language"},
-  {"name": "Kotlin", "type": "language"},
-  {"name": "React", "type": "framework"},
-  {"name": "Vue.js", "type": "framework"},
-  {"name": "Spring", "type": "framework"},
-  {"name": "Node.js", "type": "framework"},
-  {"name": "Django", "type": "framework"}
+  {
+    "name": "JavaScript",
+    "type": "language",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/javascript.png"
+  },
+  {
+    "name": "TypeScript",
+    "type": "language",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/typescript.png"
+  },
+  {
+    "name": "Java",
+    "type": "language",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/java.png"
+  },
+  {
+    "name": "Python",
+    "type": "language",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/python.png"
+  },
+  {
+    "name": "Swift",
+    "type": "language",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/swift.png"
+  },
+  {
+    "name": "Kotlin",
+    "type": "language",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/kotlin.png"
+  },
+  {
+    "name": "C",
+    "type": "language",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/c.png"
+  },
+  {
+    "name": "SQL",
+    "type": "language",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/sql.png"
+  },
+  {
+    "name": "React",
+    "type": "framework",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/react.png"
+  },
+  {
+    "name": "Vue.js",
+    "type": "framework",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/vuejs.png"
+  },
+  {
+    "name": "Spring",
+    "type": "framework",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/spring.png"
+  },
+  {
+    "name": "Node.js",
+    "type": "framework",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/nodejs.webp"
+  },
+  {
+    "name": "Django",
+    "type": "framework",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/django.jpeg"
+  },
+  {
+    "name": "Tableau",
+    "type": "Business Intelligence",
+    "icon": "https://bootme-images.s3.ap-northeast-2.amazonaws.com/logos/stack/tableau.png"
+  }
 ]
+
+### 내 프로필 조회
+GET localhost:8080/member/me HTTP/1.1
+Authorization: Bearer token
+Content-Type: application/json
 
 ### 회사 추가
 POST localhost:8080/companies HTTP/1.1


### PR DESCRIPTION
## 프로필 관리 페이지에서 사용될 API 구현
Method | Endpoint | 기능 | 목적
-- | -- | -- | --
GET | /member/me | 프로필 조회 | 프로필 관리 페이지 로드시 디폴트 데이터 fetch
GET | /stacks | BootMe 등록된 모든 스택 조회 | 프로필 관리 페이지 로드시 디폴트 데이터 fetch
PUT | /member/{memberId} | 프로필 수정 (이메일, 닉네임, 직업, 기술 스택 수정) | 프로필 관리 페이지 → 수정 완료 버튼
PATCH | /member/{memberId}/profile_image | 프로필 이미지 수정 | 프로필 관리 페이지 → 프로필 이미지 수정

<hr>

