### PR TITLE
[BE] 게시글 조회 캐싱 적용 (ElastiCache, Redis)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'org.apache.tika:tika-core:1.26'
     implementation 'com.querydsl:querydsl-jpa:5.0.0'
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'junit:junit:4.13.1'
     implementation 'com.auth0:java-jwt:3.19.0'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
     implementation 'org.jsoup:jsoup:1.13.1'
     implementation 'com.github.vladimir-bukhtoyarov:bucket4j-core:7.6.0'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:4.5.1'
     compileOnly "org.flywaydb:flyway-mysql"

--- a/backend/src/main/java/com/bootme/common/util/CustomPageImpl.java
+++ b/backend/src/main/java/com/bootme/common/util/CustomPageImpl.java
@@ -1,0 +1,25 @@
+package com.bootme.common.util;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.domain.*;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+public class CustomPageImpl<T> extends PageImpl<T> {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public CustomPageImpl(@JsonProperty("content") List<T> content,
+                    @JsonProperty("number") int page,
+                    @JsonProperty("size") int size,
+                    @JsonProperty("totalElements") long total) {
+        super(content, PageRequest.of(page, size), total);
+    }
+
+    public CustomPageImpl(Page<T> page) {
+        super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+
+}
+

--- a/backend/src/main/java/com/bootme/config/RedisCacheConfig.java
+++ b/backend/src/main/java/com/bootme/config/RedisCacheConfig.java
@@ -1,0 +1,43 @@
+package com.bootme.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    @Primary
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = generateCacheConfiguration()
+                .entryTtl(Duration.ofHours(1));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+    private RedisCacheConfiguration generateCacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer()));
+    }
+
+}

--- a/backend/src/main/java/com/bootme/config/RedisConfig.java
+++ b/backend/src/main/java/com/bootme/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.bootme.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+
+}

--- a/backend/src/main/java/com/bootme/config/RedisInitializer.java
+++ b/backend/src/main/java/com/bootme/config/RedisInitializer.java
@@ -1,0 +1,33 @@
+package com.bootme.config;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisServerCommands;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@Profile("dev")
+public class RedisInitializer implements CommandLineRunner {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RedisInitializer(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void run(String... args) {
+        flushRedisDatabase();
+    }
+
+    private void flushRedisDatabase() {
+        Optional.ofNullable(redisTemplate.getConnectionFactory())
+                .map(RedisConnectionFactory::getConnection)
+                .ifPresent(RedisServerCommands::flushDb);
+    }
+
+}

--- a/backend/src/main/java/com/bootme/post/dto/PostResponseDto.java
+++ b/backend/src/main/java/com/bootme/post/dto/PostResponseDto.java
@@ -1,5 +1,6 @@
 package com.bootme.post.dto;
 
 public interface PostResponseDto {
+    Long getId();
     void setVoted(String voteType);
 }

--- a/backend/src/main/java/com/bootme/post/repository/PostRepositoryProxy.java
+++ b/backend/src/main/java/com/bootme/post/repository/PostRepositoryProxy.java
@@ -1,0 +1,51 @@
+package com.bootme.post.repository;
+
+import com.bootme.common.util.CustomPageImpl;
+import com.bootme.post.dto.PostResponse;
+import com.querydsl.core.types.Predicate;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import static com.bootme.common.enums.SortOption.CREATED_AT;
+import static com.bootme.common.enums.SortOption.LIKES;
+
+@Component
+@RequiredArgsConstructor
+public class PostRepositoryProxy {
+
+    private final PostRepository postRepository;
+
+    @Cacheable(value = "posts", key = "#size + ':' + #sort + ':' + (#topic == '' ? 'none' : #topic) + ':' + #page")
+    public CustomPageImpl<PostResponse> getPostPage(int page, int size, String sort, String topic, Predicate predicate) {
+        Pageable pageable = getSortedPageable(page, size, sort);
+        if (predicate == null) {
+            return new CustomPageImpl<>(postRepository.findAll(pageable)
+                    .map(post -> PostResponse.of(post, false, false)));
+        } else {
+            return new CustomPageImpl<>(postRepository.findAll(predicate, pageable)
+                    .map(post -> PostResponse.of(post, false, false)));
+        }
+    }
+
+    private Pageable getSortedPageable(int page, int size, String sort) {
+        Sort sorting;
+        if (sort.equals(CREATED_AT.toString())) {
+            sorting = Sort.by(
+                    Sort.Order.desc(CREATED_AT.toString()),
+                    Sort.Order.desc(LIKES.toString())
+            );
+        } else {
+            sorting = Sort.by(
+                    Sort.Order.desc(LIKES.toString()),
+                    Sort.Order.desc(CREATED_AT.toString())
+            );
+        }
+        return PageRequest.of(page-1, size, sorting);
+    }
+
+}

--- a/backend/src/main/java/com/bootme/post/service/PostService.java
+++ b/backend/src/main/java/com/bootme/post/service/PostService.java
@@ -20,7 +20,7 @@ import com.bootme.vote.domain.Vote;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,6 +56,7 @@ public class PostService {
     }
 
     @Transactional
+    @CacheEvict(value = "posts", allEntries = true)
     public Long addPost(AuthInfo authInfo, PostRequest postRequest){
         authService.validateLogin(authInfo);
         Member member = memberService.getMemberById(authInfo.getMemberId());
@@ -110,6 +111,7 @@ public class PostService {
     }
 
     @Transactional
+    @CacheEvict(value = "posts", allEntries = true)
     public void modifyPost(AuthInfo authInfo, Long postId, PostRequest postRequest) {
         authService.validateLogin(authInfo);
         Post post = getPostById(postId);
@@ -119,6 +121,7 @@ public class PostService {
     }
 
     @Transactional
+    @CacheEvict(value = "posts", allEntries = true)
     public void deletePost(AuthInfo authInfo, Long postId) {
         authService.validateLogin(authInfo);
         Post post = getPostById(postId);

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -10,16 +10,16 @@ spring:
   jpa:
     open-in-view: false  # if true: SSE 커넥션 열려있는 동안 DB 커넥션도 열려있음 => Connection leak
     hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        default_batch_fetch_size: 100
+      ddl-auto: validate
   h2:
     console:
       enabled: true
       path: /h2-console
   flyway:
     enabled: false
+  redis:
+    host: localhost
+    port: 6379
 
 decorator:
   datasource:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -21,6 +21,9 @@ spring:
       connection:
         characterEncoding: utf8mb4
         charSet: utf8mb4
+  redis:
+    host: ENC(o+BiQ/5aXo9san8cU62L2Vb8sAdH7zpBbQ4v43qg4trz81rDXF6rnbxj2jK0NglEr8aek/tnXPqPtWw4Z10itlenYeBOa//VsvoOhvBJz2E=)
+    port: 6379
   flyway:
     enabled: true
     baseline-on-migrate: true

--- a/backend/src/main/resources/application-staging.yml
+++ b/backend/src/main/resources/application-staging.yml
@@ -21,6 +21,9 @@ spring:
       connection:
         characterEncoding: utf8mb4
         charSet: utf8mb4
+  redis:
+    host: ENC(GaOqk2YsyPFz2OP1Dm7iguh0lM++GT9ItrO4RWqiAbI99GYvnj1JYJQtwHLoZZ5ZOGNg8kHmPbEX6hbmLTJn+2tEKTFd2c8J)
+    port: 6379
   flyway:
     enabled: true
     baseline-on-migrate: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,13 +1,13 @@
 jasypt:
   encryptor:
-    password: encryptKey
+    password: G4#pLs9!tR0nG
 
 allowed-origins: http://localhost:3000,http://localhost:3001,https://bootme.co.kr,https://www.bootme.co.kr,https://staging.bootme.co.kr
 allowed-ips: ENC(nbcm5j30lelbJkCZkAUxhyeIKaSfynmWWz5QZ5j4qap3jkHlZHFwurEsapQKsKTZeqrF+W40Qh0=)
 
 spring:
   profiles:
-    active: prod
+    active: staging
   servlet:
     multipart:
       max-file-size: 10MB

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,6 +1,6 @@
 jasypt:
   encryptor:
-    password: encryptKey
+    password: G4#pLs9!tR0nG
 
 domain: localhost
 allowed-origins: http://localhost:3000,http://localhost:3001,https://bootme.co.kr,https://www.bootme.co.kr,https://staging.bootme.co.kr
@@ -18,6 +18,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  redis:
+    host: localhost
+    port: 6379
 
 cloud:
   aws:


### PR DESCRIPTION
## 배경

- 게시글 조회 API 개선 이후에도 **응답시간 약 370ms** (게시글 100만개 기준) → **추가 성능 개선 필요**
   ![image](https://github.com/Jinwook94/bootme/assets/44575214/991f5128-bedd-4ae4-8e74-7f01717dc95f)

- 쿼리 최적화로는 개선 여지를 찾기 힘들다고 판단되기 때문에, 캐싱 레이어 추가를 통해 응답시간 줄일 필요 있음
    - 응답 시간 대부분을 차지하는 쿼리의 COUNT() 함수를 사용하지 않는 방법을 찾지 못했기 때문에 더 이상 쿼리 개선을 통한 성능 향상은 어렵다고 판단

<br>

## 진행 작업

### 1. ElastiCache 클러스터 생성 및 설정

- ElastiCache Redis 클러스터 생성 (stg, prod 각각 생성)
   
- 클러스터에 적용할 보안그룹에 6379 포트 열기
    
- 클러스터 보안그룹 수정

### 2. 로컬에 redis 설치 및 실행

- ElastiCache는 동일 VPC 내에서만 접근 가능하기 때문에 로컬 환경에서 접근할 수 없음
  (로컬에서 스프링부트 실행시 ElastiCache 접근 불가)
- 그러므로 로컬 개발 환경에서는 로컬에 redis를 설치하여 테스트

### 3. 어플리케이션 코드 수정
1. 레디스 의존성 추가
2. netty-resolver-dns-native-macos 의존성 추가
3. 설정 파일에 redis host, port 추가
4. Redis Config 클래스 작성
5. 개발 환경에서 스프링부트 어플리케이션 실행시 로컬 redis 저장소가 초기화 되도록 구현
6. 게시글 조회 캐싱 적용 (`@Cacheable`, `@CacheEvict`)

<br>

## 결과 확인

- **응답시간 370ms → 10~13ms**
    
    **Before**
    
    
    ![image](https://github.com/Jinwook94/bootme/assets/44575214/0c72199f-b529-4140-ad8b-34a60f659e76)
    
    
    **After**
    
    
    ![image](https://github.com/Jinwook94/bootme/assets/44575214/52580daa-54d4-48ba-bcdc-7f833af85222)
    

    
- **캐시 키 확인**
    
    ![image](https://github.com/Jinwook94/bootme/assets/44575214/af287a53-f3ae-4ec3-9a46-822ab69f9c71)

<br> 

## 한계 및 추가 필요 작업

- 캐시 업데이트 정교화 필요
    - 현재 게시글 CUD 작업시 게시글 캐시 전체 삭제하도록 설정함
    - 각 상황별 업데이트 필요한 캐시만 삭제 되도록 정교화 필요
- 테스트 코드 작성
    - embedded-redis를 이용한 테스트 코드 작성

<br>

## 작업 중 이슈
- [Netty 관련 의존성 추가 후 M1 칩 관련 에러](https://samata94.notion.site/Netty-M1-e8210d5d626d44c9bc722c8656b31986?pvs=4)
- [Redis 데이터 수신시 역직렬화 문제 (Jackson 관련)](https://samata94.notion.site/Redis-Jackson-31f8180ced5347a8ad3b3d9e4a3a55b9?pvs=4)
- [@Cacheable - 클래스 내 다른 메서드에 의해 호출 될 때 동작하지 않음 (AOP 관련)](https://samata94.notion.site/Cacheable-AOP-c61f10b447504364b38b4e81240c264e?pvs=4)
- [API 응답 값 일부만 캐싱 필요한 상황](https://samata94.notion.site/API-ddad1ee2698847c8ae602c9f40ba9c3e?pvs=4)

<br>

## 참고 자료
- https://kth990303.tistory.com/450

<br>

closes #255 